### PR TITLE
Improve grammar across the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@
 
 The e18e (Ecosystem Performance) project is an initiative to bring together the groups and individuals who are passionate about improving performance of the JavaScript ecosystem.
 
-Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/43081j/ecosystem-cleanup) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/), and much more.
+Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/43081j/ecosystem-cleanup) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/) and much more.
 
-Our aim is to provide a space for contributions, ideas and knowledge sharing around the importance of performance across the ecosystem. Hopefully, with this collaboration, we can improve visibility of the impact of things like dependency choices. Join us at the [e18e Discord Server](https://chat.e18e.dev) to connect with other like-minded devs.
+Our aim is to provide a space for contributions, ideas and knowledge sharing around the importance of performance across the ecosystem. Hopefully, with this collaboration, we can improve visibility of the impact of things like dependency choices. Join us at the [e18e Discord server](https://chat.e18e.dev) to connect with other like-minded devs.
 
 Currently, there are three main areas of focus:
 
-- [cleanup](https://e18e.dev/guide/cleanup) - cleaning up dependency trees and modernizing popular tools and libraries across the ecosystem.
-- [speedup](https://e18e.dev/guide/speedup) - speeding up parts of the ecosystem many of us depend on.
-- [levelup](https://e18e.dev/guide/levelup) - documenting and providing modern, lighter alternatives to established tools and libraries we all regularly use.
+- [Cleanup](https://e18e.dev/guide/cleanup): cleaning up dependency trees and modernizing popular tools and libraries across the ecosystem.
+- [Speedup](https://e18e.dev/guide/speedup): speeding up parts of the ecosystem many of us depend on.
+- [Levelup](https://e18e.dev/guide/levelup): documenting and providing modern, lighter alternatives to established tools and libraries we all regularly use.
 
 ## Contributing
 
@@ -39,4 +39,4 @@ See [Contributing Guide](https://github.com/e18e/e18e/blob/main/CONTRIBUTING.md)
 
 ## License
 
-[MIT](./LICENSE) License © 2024-Present e18e Contributors
+[MIT](./LICENSE) License. © 2024 to present, e18e contributors

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { defineConfig } from 'vitepress'
 import { transformerTwoslash } from '@shikijs/vitepress-twoslash'
 import { buildEnd } from './buildEnd.config'
@@ -105,21 +106,21 @@ export default defineConfig({
               text: 'Resources',
               link: '/guide/resources',
             },
-          ]
+          ],
         },
         {
           text: 'Performance',
           items: [
             {
-              text: 'cleanup',
+              text: 'Cleanup',
               link: '/guide/cleanup',
             },
             {
-              text: 'speedup',
+              text: 'Speedup',
               link: '/guide/speedup',
             },
             {
-              text: 'levelup',
+              text: 'Levelup',
               link: '/guide/levelup',
             },
           ],

--- a/docs/blog/e18e.md
+++ b/docs/blog/e18e.md
@@ -1,5 +1,5 @@
 ---
-title: e18e (Ecosystem Performance) - A new community initiative
+title: e18e (Ecosystem Performance) - a new community initiative
 author:
   - name: The e18e Contributors
 sidebar: false
@@ -16,38 +16,38 @@ head:
       content: https://e18e.dev/blog/e18e
   - - meta
     - property: og:description
-      content: Announcing e18e - a new Ecosystem Performance focused community to connect and collaborate.
+      content: Announcing e18e - a community initiative to improve performance in the JavaScript ecosystem
 ---
 
-# e18e (Ecosystem Performance)
+# e18e (Ecosystem Performance) - a new community initiative
 
 _June 28, 2024_
 
 Today, we are excited to announce e18e!
 
-e18e is a community initiative to bring together people who are passionate about improving performance in the JavaScript ecosystem. Our goal is to provide [a space for knowledge sharing, contributions and ideas](https://chat.e18e.dev).
+e18e is a community initiative to bring together people who are passionate about improving performance in the JavaScript ecosystem. Our goal is to provide [a space for knowledge sharing, contributions, and ideas](https://chat.e18e.dev).
 
 ![e18e (Ecosystem Performance)](/e18e-og-image.png)
 
 Our focus is on three main areas:
 
-- **cleanup** - reducing, simplifying and modernizing dependency trees.
-- **speedup** - speeding up core packages and frameworks.
-- **levelup** - providing modern, lighter alternatives to core packages.
+- **Cleanup:** reducing, simplifying, and modernizing dependency trees.
+- **Speedup:** speeding up core packages and frameworks.
+- **Levelup:** providing modern, lighter alternatives to core packages.
 
-## Clean up
+## Cleanup
 
 Over time, many of us build up deeply nested trees of dependencies and lose sight of what we actually depend on. This often results in us relying on packages which are no longer maintained, or are slow, or bloated, etc.
 
-Often there are already actively maintained, battle tested alternatives but maintainers are unaware or do not have the time to move to them.
+Often there are already actively maintained, battle-tested alternatives but maintainers are unaware or do not have the time to move to them.
 
 There are several efforts to help these maintainers out by replacing or updating such dependencies:
 
-- The [ecosystem cleanup](https://github.com/43081j/ecosystem-cleanup) project.
-- The [module replacements](https://github.com/es-tooling/module-replacements) project.
-- The [eslint-plugin-depend](https://github.com/es-tooling/eslint-plugin-depend/) plugin.
+- The [ecosystem cleanup](https://github.com/43081j/ecosystem-cleanup) project
+- The [module replacements](https://github.com/es-tooling/module-replacements) project
+- The [eslint-plugin-depend](https://github.com/es-tooling/eslint-plugin-depend/) plugin
 
-## Speed up
+## Speedup
 
 Many of the core packages we depend on could benefit from performance improvements. Given how fundamental some of these packages are, a performance gain could widely affect the ecosystem in a positive way.
 
@@ -55,12 +55,12 @@ Some examples of these performance optimizations:
 
 - [Speeding up the JavaScript ecosystem](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/)
 - [Astro build performance](https://gist.github.com/bluwy/4eee1ca1ee00cc256d7c769724fe2826)
-- [Typescript package size optimizations](https://x.com/andhaveaniceday/status/1803869279017931187)
+- [TypeScript package size optimizations](https://x.com/andhaveaniceday/status/1803869279017931187)
 and Jake's blog in [similar efforts](https://jakebailey.dev/posts/pnpm-dt-2/)
 
-## Level up
+## Levelup
 
-Many well established packages have grown over time to fit more and more features, configurability and so on. Sometimes, we have use cases where this is too much for what we need, and would rather go back to the core functionality.
+Many well-established packages have grown over time to fit more and more features, configurability and so on. Sometimes, we have use cases where this is too much for what we need, and would rather go back to the core functionality.
 
 In those situations, the community has recently been building lighter alternatives - packages which often come with zero dependencies and very small install/bundle sizes.
 
@@ -73,4 +73,4 @@ Just a few great alternatives to common libraries:
 
 ## Get involved!
 
-e18e is a place to help us all connect and collaborate. If you're interested in joining some of the different efforts from folks in the community, or just want to check out what's going on - [Join the e18e discord!](https://chat.e18e.dev/)
+e18e is a place to help us all connect and collaborate. If you're interested in joining some of the different efforts from folks in the community, or just want to check out what's going on, [join the e18e Discord!](https://chat.e18e.dev/)

--- a/docs/blog/es-tooling.md
+++ b/docs/blog/es-tooling.md
@@ -1,5 +1,5 @@
 ---
-title: ES Tooling - community-led e18e-focused tooling
+title: ES Tooling - community-led tooling for e18e
 author:
   - name: James Garbutt and Pascal Schilp
 sidebar: false
@@ -10,13 +10,13 @@ head:
       content: website
   - - meta
     - property: og:title
-      content: ES tooling - community-led e18e-focused tooling
+      content: ES Tooling - community-led tooling for e18e
   - - meta
     - property: og:url
       content: https://e18e.dev/blog/es-tooling
   - - meta
     - property: og:description
-      content: ES Tooling - a community-led , e18e-focused collection of tools for the ecosystem
+      content: ES Tooling - a community-led, e18e-focused collection of tools for the ecosystem
 ---
 
 # ES Tooling
@@ -31,22 +31,22 @@ If you haven't yet encountered e18e, read more in the [guide](https://e18e.dev/g
 
 ## A home for e18e-focused tools
 
-Over the last few months, many of us have collaborated and connected through the e18e community. The ES tooling organization is a result of that - a place for us to store and own forks, tools, and other code bases we're working on together.
+Over the last few months, many of us have collaborated and connected through the e18e community. The ES Tooling organization is a result of that - a place for us to store and own forks, tools, and other codebases we're working on together.
 
-A few popular projects that were running solo until now, have come together to create this:
+A few popular projects that were running solo until now have come together to create this:
 
 - [ecosystem-cleanup](https://github.com/43081j/ecosystem-cleanup).
 - [module-replacements](https://github.com/es-tooling/module-replacements).
 - [module-replacements-codemods](https://github.com/thepassle/module-replacements-codemods)
 - [fd-package-json](https://github.com/es-tooling/fd-package-json)
 
-While e18e exists to connect us all and provide a space to collaborate, it doesn't exist to own the projects coming out of the initiative. That is where projects like es-tooling, unjs and more come in to play.
+While e18e exists to connect us all and provide a space to collaborate, it doesn't exist to own the projects coming out of the initiative. That is where projects like ES Tooling, unjs and more come in to play.
 
-**We expect es-tooling will be one of many community-led orgs with an e18e focus.**
+**We expect ES Tooling will be one of many community-led organizations with an e18e focus.**
 
 ## Ecosystem cleanup
 
-One of the projects which kicked much of this initiative off - the ecosystem cleanup project has now moved into the ES Tooling organization to allow better visibility and maintenance.
+One of the projects which kicked much of this initiative off, the ecosystem cleanup project, has now moved into the ES Tooling organization to allow better visibility and maintenance.
 
 The cleanup project exists primarily as an issue tracker, tracking:
 
@@ -68,16 +68,14 @@ Read more at the [module replacements project](https://github.com/es-tooling/mod
 
 ## Module replacements codemods
 
-The module replacements codemods project is an effort to automate the ecosystem cleanup. Taking the module replacements as input, we aim to have automated codemods for all packages listed. This way other tooling can use these codemods to perform transformations on projects automatically. For example, a codemod for the `is-even` package would result in:
+The module replacements codemods project is an effort to automate ecosystem cleanup. Taking the module replacements as input, we aim to have automated codemods for all packages listed. This way other tooling can use these codemods to perform transformations on projects automatically. For example, a codemod for the `is-even` package would result in:
 
-Before:
 ```js
+// Before:
 const isEven = require('is-even')
 console.log(isEven(2))
-```
 
-After:
-```js
+// After:
 console.log(2 % 2 === 0)
 ```
 
@@ -87,4 +85,4 @@ You can find more information about the [module replacements codemods](https://g
 
 ## What's next?
 
-If you own an e18e-focused project, or need a home for a new project, [get involved!](https://chat.e18e.dev/)
+If you own an e18e-focused project, or need a home for a new project, [get involved](https://chat.e18e.dev/)!

--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -1,10 +1,10 @@
 # Cleanup
 
-The JavaScript ecosystem has grown massively over the years, in good and bad ways. We have all the packages and choice we want, but have built up a vast amount of technical debt along the way.
+The JavaScript ecosystem has grown massively over the years, in both good and bad ways. We have all the packages and choice we want, but have built up a vast amount of technical debt along the way.
 
-Much of this is in the form of packages which are redundant, bloated or have since fallen out of active maintenance.
+Much of this is in the form of packages which are redundant, bloated, or have since fallen out of active maintenance.
 
-A good example of the current efforts to clean our packages up, is [es-tooling/ecosystem-cleanup](https://github.com/es-tooling/ecosystem-cleanup). This project aims to drive contributions upstream to popular open-source projects. The project aims to:
+A good example of the current efforts to clean our packages up is [es-tooling/ecosystem-cleanup](https://github.com/es-tooling/ecosystem-cleanup). This project aims to drive contributions upstream to popular open-source projects. The project aims to:
 
 - Modernize existing packages
 - Migrate from redundant packages
@@ -12,9 +12,9 @@ A good example of the current efforts to clean our packages up, is [es-tooling/e
 - Migrate to lighter and/or faster alternatives
 
 ::: info Jump into action!
-The es-tooling community maintains a list of [open opportunities in the ecosystem-cleanup repo](https://github.com/43081j/ecosystem-cleanup/issues). After reading this guide, check out these issues for ideas to improve popular packages. And if you do research and find other places we can clean up a dependency tree, or speed it up, please do open some tracking issues in the cleanup repo, so you give others good starting points to get involved.
+The es-tooling community maintains a list of [open opportunities in the ecosystem-cleanup repo](https://github.com/43081j/ecosystem-cleanup/issues). After reading this guide, check out these issues for ideas to improve popular packages. And if you do research and find other places we can clean up a dependency tree, or speed it up, please open some tracking issues in the cleanup repo, so you give others good starting points to get involved.
 
-We can have a bigger effect working together. Join the [e18e Discord server](https://chat.e18e.dev) to connect with others to share your wins or get help along the way!
+We can have a bigger effect by working together. Join the [e18e Discord server](https://chat.e18e.dev) to connect with others to share your wins or get help along the way!
 :::
 
 ## Contribution Guide
@@ -31,28 +31,24 @@ We're mostly looking for packages which fit the following criteria:
 - Slow
 - Redundant
 
-A good start to this is to choose the **target package** you want to improve. For example, we could choose to improve [vite](https://github.com/vitejs/vite).
+A good start to this is to choose the **target package** you want to improve. For example, we could choose to improve [Vite](https://github.com/vitejs/vite).
 
-Our first step is to _discover_ the current state of this package.
-
-We can do that with [npmgraph](https://npmgraph.js.org/) and [pkg-size](https://pkg-size.dev/).
-
-In this case, we can visualize vite's dependency graph and size here:
+Our first step is to **discover** the current state of this package. We can do that with [npmgraph](https://npmgraph.js.org/) and [pkg-size](https://pkg-size.dev/). In this case, we can visualize Vite's dependency graph and size here:
 
 - [vite dependency graph](https://npmgraph.js.org/?q=vite)
 - [vite package size](https://pkg-size.dev/vite)
 
-This should give us a good idea of dependency tree complexity and overall _install size_ (amount of data you'll pull down on install).
+This should give us a good idea of dependency tree complexity and overall install size (amount of data you'll pull down on install).
 
 #### Rollup bundles
 
-In our particular example, vite seems to have very few dependencies and has an install size we can probably reduce (32MB at time of writing this).
+In our particular example, Vite seems to have very few dependencies and has an install size we can probably reduce (32MB at time of writing this).
 
-This is because vite bundles many of their production dependencies rather than pulling them in from `node_modules`.
+This is because Vite bundles many of their production dependencies, rather than pulling them in from `node_modules`.
 
-Due to this, we have to go a little further: rollup bundle analysis.
+Due to this, we have to go a little further: **Rollup bundle analysis**.
 
-We can use the [`rollup-plugin-visualizer`](https://github.com/btd/rollup-plugin-visualizer) plugin to generate a visualization of vite's bundle.
+We can use the [`rollup-plugin-visualizer`](https://github.com/btd/rollup-plugin-visualizer) plugin to generate a visualization of Vite's bundle.
 
 From the visualization this produces, you should quickly get a good idea of the larger dependencies in the bundle and the tree that leads to them being imported.
 
@@ -60,47 +56,43 @@ From the visualization this produces, you should quickly get a good idea of the 
 
 Easy wins in the dependency graph are often those packages which themselves pull in very large subtrees of dependencies.
 
-While this is usually true, some of those deep dependencies do have their uses (e.g. older node versions). Remember to take this into account before assuming we can remove the tree from the dependency list.
+While this is usually true, some of those deep dependencies do have their uses (e.g. older Node versions). Remember to take this into account before assuming we can remove the tree from the dependency list.
 
 ### Improvement
 
-Now that we've seen the dependency graph, the package size and the bundle size/distribution, we can begin to think of improvements.
+Now that we've seen the dependency graph, the package size, and the bundle size/distribution, we can begin to think of improvements.
 
 What we should be looking for:
 
-- Dependencies which pull in large subtrees of deeper dependencies which themselves are not depended on by anything outside of the subtree.
-- Dependencies which are duplicated (either through multiple versions, or multiple dependencies achieving the same goals).
-- Very large (install size) dependencies.
+- Dependencies which pull in large subtrees of deeper dependencies which themselves are not depended on by anything outside of the subtree
+- Dependencies which are duplicated (either through multiple versions, or multiple dependencies achieving the same goals)
+- Very large dependencies (in terms of install size)
 
-Back to our vite example - at the time of writing this, we can see in the rollup bundle that both `fast-glob` and `glob` are bundled into vite.
+Back to our Vite example - at the time of writing this, we can see in the Rollup bundle that both `fast-glob` and `glob` are bundled into Vite.
 
-This will mean we are bundling two non-trivial packages which essentially do the same thing. We have found a possible performance improvement!
+This means we are bundling two non-trivial packages which essentially do the same thing. We have found a possible performance improvement!
 
 #### Create cleanup issues
 
-At this point, if you have identified some potential performance improvements, you should open issues in this repository.
+At this point, if you have identified some potential performance improvements, you should open issues in the [ecosystem-cleanup](https://github.com/es-tooling/ecosystem-cleanup/issues) repository.
 
-Even if you will try tackle them yourself, this will help improve visibility so people do not duplicate work and can help you out.
+Even if you will try tackle them yourself, this will help improve visibility so people do not duplicate work and can help you out. Or, if you do not have time to tackle it yourself, it is possible for someone else to follow your findings.
 
-Or if you do not have time to tackle it yourself, it is possible someone else can follow your findings.
-
-Feel free to also attach a package report using [DevMiner's package-size-calculator](https://github.com/TheDevMinerTV/package-size-calculator) to the issue, to give an overview over the package's size and the changes you are proposing.
+Feel free to also attach a package report using [DevMiner's package-size-calculator](https://github.com/TheDevMinerTV/package-size-calculator) to the issue, to give an overview of the package's size and the changes you are proposing.
 
 ### Fixes
 
-We've now identified some dependency which introduces performance problems.
-
-Depending on the type of improvement we've identified, there are a few different approaches for providing a fix/change.
+We've now identified a dependency which introduces performance problems. Depending on the type of improvement we've identified, there are a few different approaches for providing a fix/change.
 
 #### Large subtrees
 
-For these dependencies, we should first find out if there's a reason we need them and not an alternative.
+For these dependencies, we should first find out if there's a reason the dependency is necessary and shouldn't be replaced with an alternative.
 
 Common things to check:
 
-- node `engines` specifying a node version low enough that this dependency supports (and alternatives don't).
-- there is no known alternative (good opportunity to make one!).
-- every deep dependency in the subtree is necessary (in many cases the tree may be deep but for good reason, to share modules, etc).
+- [`engines`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines) specifying a lower Node version that this dependency supports, but alternatives don't
+- Whether there is any known alternative (if not, there is a good opportunity to make one!)
+- If every deep dependency in the subtree is necessary (in many cases the tree may be deep but for good reason, to share modules, etc.)
 
 If it is indeed replaceable, you should find an alternative. Good resources for that are:
 
@@ -108,25 +100,23 @@ If it is indeed replaceable, you should find an alternative. Good resources for 
 - [tinylibs](https://github.com/tinylibs/)
 - [unjs](https://github.com/unjs/)
 
-Many more will also exist. If you find a good, leaner alternative, [share it with the rest of us!](https://chat.e18e.dev)
+Many more may also exist. If you find a good, leaner alternative, [share it with the rest of us](https://chat.e18e.dev)!
 
 #### Duplicated functionality
 
-Often you will find dependencies which use separate versions, or separate solutions entirely to achieve the same piece of functionality.
+Often you will find multiple versions of the same dependency, or multiple dependencies entirely, to achieve the same overall functionality.
 
-In the case of separate versions, we should contribute upstream to update the one which is behind to the latest version (or both if neither is up to date).
+In the case of multiple versions, we should contribute upstream to update the older one to the latest version (or both if neither is up to date).
 
-In the case of separate solutions, we should see if one solution is better than the other and consider migrating the other if this is the case.
+In the case of multiple packages, we should see if one solution is better than the other and consider migrating the other if this is the case.
 
-In our vite example, we would see what uses `fast-glob`, and what uses `glob`. We would then compare the two libraries and alternatives, to find if the dependencies pulling these in could use the same solution, or a newer and better solution.
+In our Vite example, we would see what uses `fast-glob`, and what uses `glob`. We would then compare the two libraries and alternatives, to find if the dependencies pulling these in could use the same solution, or a newer and better solution.
 
 #### Large dependencies
 
-If you find a large dependency, it is usually the case that it contains far more (useful) functionality than we need.
+If you find a large dependency, it is usually the case that it contains far more functionality than we need.
 
 The fix here is often that we either:
 
-- Contribute upstream to split the dependency up into more granular modules (but not _too_ granular).
-- Move to a dependency which is leaner and is more focused.
-
-In this situation, it is worth looking for a lighter (and hopefully faster) alternative.
+- Contribute upstream to split the dependency up into more granular modules (but not _too_ granular)
+- Move to a dependency which is leaner and is more focused

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,14 +2,12 @@
 
 The e18e project is an initiative to bring together the groups and individuals who are passionate about improving performance of the JavaScript ecosystem.
 
-Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/43081j/ecosystem-cleanup) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/),
-and much more.
+Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/43081j/ecosystem-cleanup) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/), and much more.
 
-Our aim is to provide a space for contributions, ideas and knowledge sharing around the importance of performance across the ecosystem. Hopefully, with this collaboration, we can improve visibility of the impact of things like
-dependency choices. Join us at the [e18e Discord Server](https://chat.e18e.dev) to connect with other like-minded devs.
+Our aim is to provide a space for contributions, ideas, and knowledge sharing around the importance of performance across the ecosystem. Hopefully, with this collaboration, we can improve visibility of the impact of things like dependency choices. Join us in the [e18e Discord Server](https://chat.e18e.dev) to connect with other like-minded devs.
 
 Currently, there are three main areas of focus:
 
-- [cleanup](./cleanup.md) - cleaning up dependency trees and modernizing popular tools and libraries across the ecosystem.
-- [speedup](./speedup.md) - speeding up parts of the ecosystem many of us depend on.
-- [levelup](./levelup.md) - documenting and providing modern, lighter alternatives to established tools and libraries we all regularly use.
+- [Cleanup](./cleanup.md): cleaning up dependency trees and modernizing popular tools and libraries across the ecosystem
+- [Speedup](./speedup.md): speeding up parts of the ecosystem many of us depend on
+- [Levelup](./levelup.md): documenting and providing modern, lighter alternatives to established tools and libraries we all regularly use

--- a/docs/guide/levelup.md
+++ b/docs/guide/levelup.md
@@ -1,8 +1,8 @@
 # Levelup
 
-Especially with the features modern runtimes bring today, many packages can now be leaner, faster and more focused.
+With the features available today in modern JavaScript runtimes, many packages can now be leaner, faster, and more focused.
 
-Just like the introduction of esbuild as a lean alternative when you don't need the full customisability of webpack, these packages are here to be **fast and small**.
+Just like the introduction of esbuild as a lean alternative when you don't need the full customizability of webpack, these packages are here to be **fast and small**.
 
 Some projects contributing heavily to this effort:
 
@@ -10,4 +10,4 @@ Some projects contributing heavily to this effort:
 - [unjs](https://github.com/unjs/)
 - [es-tooling](https://github.com/es-tooling/)
 
-The levelup and cleanup efforts cross paths often, as these focused packages greatly reduce your install size while giving you great perf boosts.
+The levelup and cleanup efforts cross paths often, as these focused packages greatly reduce install size while giving great performance boosts.

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -13,7 +13,7 @@
 
 |  | Description |
 | -- | -- |
-| [eslint-plugin-depend](https://github.com/es-tooling/eslint-plugin-depend) | ESLint plugin to suggest dependencies alternatives |
+| [eslint-plugin-depend](https://github.com/es-tooling/eslint-plugin-depend) | ESLint plugin to suggest alternative dependencies |
 | [eslint-plugin-barrel-files](https://github.com/thepassle/eslint-plugin-barrel-files) | ESLint plugin to avoid barrel files |
 | [Biome's noBarrelFile](https://biomejs.dev/linter/rules/no-barrel-file/) | Biome plugin to avoid barrel files |
 | [Biome's noReExportAll](https://biomejs.dev/linter/rules/no-re-export-all/) | Biome plugin to avoid re-export all |
@@ -25,10 +25,10 @@
 |  | Description |
 | -- | -- |
 | [DepTree](https://deptree.rschristian.dev/) | Visualizes a project's dependencies and highlights which of those dependencies could be replaced |
-| [npmgraph](https://npmgraph.js.org/) | Visually displays a graph of a project's dependencies to get an idea of a projects module graph |
-| [Ecosyste.ms](https://packages.ecosyste.ms/) | An open API service providing package, version and dependency metadata of many open source software ecosystems and registries |
+| [npmgraph](https://npmgraph.js.org/) | Visually displays a graph of a project's dependencies to get an idea of a project's module graph |
+| [Ecosyste.ms](https://packages.ecosyste.ms/) | An open API service providing package, version, and dependency metadata of many open-source software ecosystems and registries |
 
 ## Learning
 
-- [Marvin's Speeding Up the JS Ecosystem series](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/)
+- [Marvin's series on Speeding Up the JS Ecosystem](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/)
 - [Practical barrel file guide for library authors](https://thepassle.netlify.app/blog/practical-barrel-file-guide-for-library-authors)

--- a/docs/guide/speedup.md
+++ b/docs/guide/speedup.md
@@ -4,7 +4,7 @@ A major part of improving the ecosystem for everyone is _speed_. The speed of co
 
 A few groups and individuals are working in this space. Just some of these are listed below:
 
-- [Speeding up the Javascript Ecosystem](https://marvinh.dev/blog/speeding-up-javascript-ecosystem).
+- [Speeding up the Javascript Ecosystem](https://marvinh.dev/blog/speeding-up-javascript-ecosystem)
 
 ## Linting
 
@@ -12,7 +12,7 @@ Some performance improvements can be detected via a linter.
 
 ### ESLint
 
-For those of us using ESLint, a few plugins are available which strongly align with the principals of the e18e effort:
+For those of us using ESLint, a few plugins are available which strongly align with the principles of the e18e effort:
 
 | Plugin | Description |
 | -- | -- |
@@ -35,7 +35,7 @@ The code you write plays an important role in the performance of your app. Some 
 
 ### Avoid generators for hot code paths
 
-At the moment, most JavaScript engines do not optimize [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) function calls which leads to a large performance hit if used extensively.
+At the moment, most JavaScript engines do not optimize [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) function calls, leading to a large performance hit if used extensively.
 
 Prefer using non-async [iterators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) or plain arrays.
 
@@ -43,4 +43,4 @@ Prefer using non-async [iterators](https://developer.mozilla.org/en-US/docs/Web/
 
 Chaining array methods like `map`, `filter`, `reduce`, etc leads to many intermediate arrays being created and disposed, causing more work for the garbage collector. Each chain also leads to an extra iteration, which can be more times than needed.
 
-Prefer using [`for` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for), [`for...in` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), and[`for...of` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), or a single chain method only to prevent the caveats above.
+Prefer using [`for` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for), [`for...in` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), and[`for...of` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), or a single chain method to prevent the above issues.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ titleTemplate: Ecosystem Performance
 hero:
   name: e18e
   text: Ecosystem Performance
-  tagline: Cleanup, Speedup, Levelup.<br>One Package at a time.
+  tagline: Cleanup. Speedup. Levelup.<br>One package at a time.
   image:
     src: /logo.svg
     alt: e18e
@@ -36,10 +36,10 @@ features:
 
 ## Welcome to e18e!
 
-e18e (Ecosystem Performance) is an initiative to connect the folks and projects working to improve JS packages performance.
+e18e (Ecosystem Performance) is an initiative to improve the state of the JavaScript ecosystem.
 
-We'd also like to provide visibility to the efforts of countless Open Source developers working to cleanup, levelup, and speedup our dependencies.
+We also provide visibility into the efforts of countless open-source developers working to **clean up**, **speed up**, and **level up** our dependencies.
 
-We invite you to get involved in the different projects linked from these pages, and to connect with others like-minded folks.
+We invite you to get involved in the different projects linked from these pages, and to connect with other like-minded folks.
 
-Join us at the [e18e Discord server](https://chat.e18e.dev) and collaborate with us!
+Join us in the [e18e Discord server](https://chat.e18e.dev) and collaborate with us!


### PR DESCRIPTION
This incorporates many of the changes that were abandoned in #16, plus a few other scattered changes.

As I mentioned on Discord, I am an Oxford comma enthusiast, and believe they should always be used in all situations. If we really would prefer to omit the Oxford comma across the site, I will begrudgingly update my PR to do so, but not without complaining :stuck_out_tongue: 

As for the perhaps contentious issue of "cleanup" vs. "clean up" - in most cases, I have gone with "cleanup", with the understanding that it is to be thought of in context like "the e18e cleanup initiative". I have in one or two places phrased it "clean up" where it is explicitly used as a verb (e.g. "clean up the ecosystem").