### PR TITLE
docs: add "unused" criterium and Knip tool

### DIFF
--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -30,6 +30,7 @@ We're mostly looking for packages which fit the following criteria:
 - Outdated
 - Slow
 - Redundant
+- Unused
 
 A good start to this is to choose the **target package** you want to improve. For example, we could choose to improve [vite](https://github.com/vitejs/vite).
 

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -19,6 +19,7 @@
 | [Biome's noReExportAll](https://biomejs.dev/linter/rules/no-re-export-all/) | Biome plugin to avoid re-export all |
 | [unplugin-purge-polyfills](https://github.com/danielroe/unplugin-purge-polyfills) | Unplugin to replace package imports with native code |
 | [Package Size Calculator](https://github.com/TheDevMinerTV/package-size-calculator) | CLI to calculate the size of a package after removing/replacing dependencies, or calculating the difference of two versions of the same package |
+| [Knip](https://knip.dev) | Find unused files, dependencies and exports |
 
 ## Websites
 


### PR DESCRIPTION
I interpret "unused" different from "obsolete", e.g. a package becomes obsolete when a native/built-in API is available (as opposed to not being referenced at all).

Adding Knip here too (I'm the creator), to chase unused deps.