### PR TITLE
docs: add `howfat` to Tools

### DIFF
--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -19,6 +19,7 @@
 | [Biome's noReExportAll](https://biomejs.dev/linter/rules/no-re-export-all/) | Biome plugin to avoid re-export all |
 | [unplugin-purge-polyfills](https://github.com/danielroe/unplugin-purge-polyfills) | Unplugin to replace package imports with native code |
 | [Package Size Calculator](https://github.com/TheDevMinerTV/package-size-calculator) | CLI to calculate the size of a package after removing/replacing dependencies, or calculating the difference of two versions of the same package |
+| [howfat](https://github.com/megahertz/howfat) | Shows how much space a package takes up on disk including dependencies |
 | [Knip](https://knip.dev) | Find unused files, dependencies and exports |
 
 ## Websites


### PR DESCRIPTION
`howfat` checks how much space a package and all its dependencies weigh on disk.

I'm not affiliated with the package, but I've been using it more and more to compare alternatives, when I'm considering adding a new dependency.

Let me know what you think 🙂

```sh
npx howfat -r table dequal
dequal@2.0.3 (13.9kb, 11 files, ©MIT)
no dependencies
```

```sh
npx howfat -r table deep-equal-json
╭───────────────────┬──────────────┬──────────┬───────┬───────────┬─────────┬───────────╮
│ Name              │ Dependencies │     Size │ Files │ Native    │ License │ Deprec    │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ call-bind@1.0.7   │           11 │ 219.57kb │   139 │           │ MIT     │           │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ isarray@2.0.5     │              │   3.35kb │     4 │           │ MIT     │           │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ object-is@1.1.6   │           16 │ 325.25kb │   194 │           │ MIT     │           │
├───────────────────┼──────────────┼──────────┼───────┼───────────┼─────────┼───────────┤
│ object-keys@1.1.1 │              │  25.92kb │    11 │           │ MIT     │           │
╰───────────────────┴──────────────┴──────────┴───────┴───────────┴─────────┴───────────╯
```