### PR TITLE
docs: correct phrase about PostCSS in August blog post

### DIFF
--- a/docs/blog/august-contributions-showcase.md
+++ b/docs/blog/august-contributions-showcase.md
@@ -148,9 +148,7 @@ To get an idea of the change, take a look at the npmgraph [before](https://npmgr
 
 ## postcss
 
-The PostCSS maintainers are taking a good focus on e18e lately. In [postcss-mixins](https://www.npmjs.com/package/postcss-mixins), the size has gone from 1.3MB to 930KB, dropping ~15 dependencies.
-
-Great work by [@sitnikcode](https://x.com/sitnikcode) and the team on taking an e18e focus recently.
+The PostCSS maintainers improved [postcss-mixins](https://www.npmjs.com/package/postcss-mixins), with its size going from 1.3MB to 930KB, dropping ~15 dependencies. Great work by [@sitnikcode](https://x.com/sitnikcode) and the team, continuing their long tradition of caring about the size of their user’s node_modules.
 
 # Get involved
 


### PR DESCRIPTION
They are writing about reducing node_modules size since 2017 (!) 😎
https://evilmartians.com/chronicles/autoprefixer-7-browserslist-2-released
https://x.com/PostCSS/status/1276669602324504580