### PR TITLE
docs: add `pkg-graph` to websites

### DIFF
--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -29,6 +29,7 @@
 | [DepTree](https://deptree.rschristian.dev/) | Visualizes a project's dependencies and highlights which of those dependencies could be replaced |
 | [npmgraph](https://npmgraph.js.org/) | Visually displays a graph of a project's dependencies to get an idea of a projects module graph |
 | [Ecosyste.ms](https://packages.ecosyste.ms/) | An open API service providing package, version and dependency metadata of many open source software ecosystems and registries |
+| [pkg-graph](https://pkg-graph.info/) | Visualize the dependency graph of npm packages |
 
 ## Learning
 

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -29,7 +29,7 @@
 | [DepTree](https://deptree.rschristian.dev/) | Visualizes a project's dependencies and highlights which of those dependencies could be replaced |
 | [npmgraph](https://npmgraph.js.org/) | Visually displays a graph of a project's dependencies to get an idea of a projects module graph |
 | [Ecosyste.ms](https://packages.ecosyste.ms/) | An open API service providing package, version and dependency metadata of many open source software ecosystems and registries |
-| [pkg-graph](https://pkg-graph.info/) | Visualize the dependency graph of npm packages |
+| [pkg-graph](https://pkg-graph.info/) | Visualize the dependency graph of packages |
 
 ## Learning
 


### PR DESCRIPTION
Another website tools to visualizes a package's dependency graph.
It base on Webcontainer, so when analyzing large packages, it will be faster than other similar tools.

Homepage: https://pkg-graph.info/
GitHub: https://github.com/yuyinws/pkg-graph.info