### PR TITLE
docs: correct headings of blog posts

### DIFF
--- a/docs/blog/august-contributions-showcase.md
+++ b/docs/blog/august-contributions-showcase.md
@@ -27,11 +27,11 @@ This post is a little late thanks to me being stuck in the middle of a super typ
 
 If you want to get involved, remember to come [join the discussion](https://chat.e18e.dev)!
 
-# Libraries
+## Libraries
 
 Here are just some of the great libraries we've seen this August.
 
-## tinyexec
+### tinyexec
 
 [tinyexec](https://github.com/tinylibs/tinyexec) is a new library from the [tinylibs](https://github.com/tinylibs) group to provide a super lightweight abstraction around `child_process`.
 
@@ -49,7 +49,7 @@ In many places where we need to launch a command, we don't need a high level abs
 
 For places where we do want a higher level interface, we still have projects like [zx](https://github.com/google/zx).
 
-## tinyglobby / fdir
+### tinyglobby / fdir
 
 Much of the community has been hard at work moving projects away from various heavyweight glob libraries to [fdir](https://github.com/thecodrr/fdir).
 
@@ -77,7 +77,7 @@ So many projects have been quick to adopt these libraries, saving on install siz
 
 Great work by both [@thecodrr](https://x.com/thecodrr) and [@superchupudev](https://x.com/superchupu) here!
 
-## package-manager-detector
+### package-manager-detector
 
 [`package-manager-detector`](https://github.com/antfu-collective/package-manager-detector) is used to detect the local package manager (e.g. `npm`, `pnpm`, `yarn`, etc.)
 
@@ -87,7 +87,7 @@ As an example, [@benjaminmccann](https://x.com/benjaminmccann) switched from `pr
 
 Thanks to [@antfu7](https://x.com/antfu7) and [@userquin](https://x.com/userquin) for building this!
 
-## tschema
+### tschema
 
 [tschema](https://github.com/lukeed/tschema) is a cool new library to generate JSON schema types by [@lukeed05](https://x.com/lukeed05).
 
@@ -101,23 +101,23 @@ const User = t.object({
 })
 ```
 
-## knip
+### knip
 
 [knip](https://github.com/webpro-nl/knip) is a tool for detecting unused files and dependencies in your project. This has been incredibly useful and widely used across the e18e community already.
 
 For example, [mocha](https://github.com/mochajs/mocha/pull/5042) has already adopted this and cleaned up a huge amount of deep dependencies thanks to the efforts of [@voxpelli](https://x.com/voxpelli).
 
-# Contributions / Improvements
+## Contributions / Improvements
 
 As well as some cool new libraries, we've seen many great contributions to performance and clean up across the ecosystem.
 
-## dotenvx
+### dotenvx
 
 The maintainers of [dotenvx](https://github.com/dotenvx/dotenvx) have been hard at work with [@superchupudev](https://x.com/superchupu) to massively reduce the install size and depedency tree complexity.
 
 Down from [142 dependencies](https://npmgraph.js.org/?q=@dotenvx/dotenvx@1.0.0) to only [28 dependencies](https://npmgraph.js.org/?q=@dotenvx/dotenvx), this is a great achievement :tada:
 
-## changesets
+### changesets
 
 The [changesets](https://github.com/changesets/changesets) project has been busy merging _many_ e18e-focused improvements.
 
@@ -125,7 +125,7 @@ Just a quick look at the [changelog](https://github.com/changesets/changesets/re
 
 Thanks to [@bluwyoo](https://x.com/bluwyoo), [@benjaminmccann](https://x.com/benjaminmccann) and [@trivikram](https://x.com/trivikram) in particular for pushing this forward :pray:
 
-## picocolors
+### picocolors
 
 [picocolors](https://github.com/alexeyraspopov/picocolors) has been around a while already, but recently published a new version with support for bright variants of colours.
 
@@ -135,7 +135,7 @@ If you need terminal colors, this is the one to use.
 
 If you're using node 20 or above, and don't need to support older runtimes, also check out [styleText](https://nodejs.org/api/util.html#utilstyletextformat-text-options) which is built in!
 
-## payload CMS
+### payload CMS
 
 The [payload CMS](https://github.com/payloadcms/payload/) team have been doing some impressive work optimizing the install size and performance of their packages.
 
@@ -146,11 +146,11 @@ Some quick stats:
 
 To get an idea of the change, take a look at the npmgraph [before](https://npmgraph.js.org/?q=payload@2) and [after](https://npmgraph.js.org/?q=payload@3.0.0-beta.100).
 
-## postcss
+### postcss
 
 The PostCSS maintainers improved [postcss-mixins](https://www.npmjs.com/package/postcss-mixins), with its size going from 1.3MB to 930KB, dropping ~15 dependencies. Great work by [@sitnikcode](https://x.com/sitnikcode) and the team, continuing their long tradition of caring about the size of their user’s node_modules.
 
-# Get involved
+## Get involved
 
 If you want to help out, [join the discord](https://chat.e18e.dev). We'd love to have the help :pray:
 

--- a/docs/blog/july-contributions-showcase.md
+++ b/docs/blog/july-contributions-showcase.md
@@ -29,7 +29,7 @@ Most of us will have been affected by these contributions somewhere down the lin
 
 The people contributing these changes deserve so many thanks for their work, so here is a summary of some of the highlights from the past month!
 
-# `svelte-preprocess` becomes dependency-free
+## `svelte-preprocess` becomes dependency-free
 
 The svelte team have been busy reducing the footprint of [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess).
 
@@ -45,7 +45,7 @@ You can read about how this was achieve through these two PRs in particular:
 - https://github.com/sveltejs/svelte-preprocess/pull/640
 - https://github.com/sveltejs/svelte-preprocess/pull/645
 
-# codemods
+## codemods
 
 One of the biggest steps forward with the [replacements project](https://github.com/es-tooling/module-replacements) has certainly been the [codemods](https://github.com/es-tooling/module-replacements-codemods) repo.
 
@@ -57,7 +57,7 @@ The [codemods project](https://github.com/es-tooling/module-replacements-codemod
 
 The future of the [es-tooling](https://github.com/es-tooling) organisation will likely involve a CLI which can apply these codemods for you. Keep an eye out for it in future!
 
-# Removing `is-number` from `micromatch`
+## Removing `is-number` from `micromatch`
 
 While this hasn't been published yet, it is great progress, showing that even some aged projects are open to performance contributions.
 
@@ -67,7 +67,7 @@ While this hasn't been published yet, it is great progress, showing that even so
 
 Credit to [@talentlessguy](https://github.com/talentlessguy) for this contribution!
 
-# Removing `rimraf` from `node-pre-gyp`
+## Removing `rimraf` from `node-pre-gyp`
 
 Node has had a `recursive` option for `rmdir` (or `rm` in newer versions) for a while now. This can achieve the same functionality `rimraf` was providing in many cases.
 
@@ -77,7 +77,7 @@ It is worth mentioning, for those cases where you'd still like a CLI, you can us
 
 Credit to [@benjaminmccann](https://x.com/benjaminmccann) for this one!
 
-# picoquery
+## picoquery
 
 As part of the [cleanup project](https://github.com/es-tooling/ecosystem-cleanup), we were in need of a fast and lightweight query-string parser/stringifier.
 
@@ -92,7 +92,7 @@ This is why [picoquery](https://github.com/43081j/picoquery) was born! A super f
 
 Our hope is that we see more and more of these alternatives being produced by the community. Many popular, bloated or outdated packages still need alternatives. Join the [discussion](https://chat.e18e.dev) if you're interested!
 
-# neotraverse
+## neotraverse
 
 Similar to how `picoquery` came about, we needed a lighter alternative to the popular `traverse` package.
 
@@ -103,7 +103,7 @@ The savings are great:
 - **traverse:** 3.9MB / 67 packages
 - **neotraverse:** 140KB / 1 package
 
-# package-size-calculator
+## package-size-calculator
 
 Built by [@DevMiner](https://github.com/TheDevMinerTV), this is a cool little CLI that can provide package size stats and an estimate of the monthly bandwidth usage.
 

--- a/docs/blog/september-contributions-showcase.md
+++ b/docs/blog/september-contributions-showcase.md
@@ -25,11 +25,11 @@ _October 6, 2024_
 
 It's that time of month again where we show off some of the great contributions we've seen around the e18e community in the past month!
 
-# Libraries
+## Libraries
 
 This month has been a great one for improvements to existing and upcoming libraries. Many have been listening closely to the e18e community and pushing forward together.
 
-## chokidar 4.x
+### chokidar 4.x
 
 [chokidar](https://github.com/paulmillr/chokidar) is a library for watching for changes on a file system. Built on top of node's own watcher capabilities, it provides a higher level and simpler interface.
 
@@ -45,7 +45,7 @@ Big wins for the e18e community!
 
 Thanks to [@benjaminmccann](https://x.com/benjaminmccann) and talentlessguy for contributing _many_ v3 to v4 upgrades already!
 
-## fdir / tinyglobby
+### fdir / tinyglobby
 
 `fdir` was in last month's showcase but has earned another mention thanks to the author ([thecodrr](https://x.com/thecodrr)) landing various community contributed PRs and features.
 
@@ -62,7 +62,7 @@ Similarly, [tinyglobby](https://github.com/SuperchupuDev/tinyglobby) has shipped
 
 Thanks to [pralkarz](https://github.com/ziebam), [@benjaminmccann](https://x.com/benjaminmccann) and [@superchupudev](https://x.com/superchupu) for already migrating so many projects to these two libraries!
 
-## tinyexec migrations
+### tinyexec migrations
 
 The community has been working wonders migrating countless projects from `execa`, `ez-spawn`, and other libraries to the super lean [tinyexec](https://github.com/tinylibs/tinyexec/).
 
@@ -70,9 +70,9 @@ For example, thanks to [pralkarz](https://github.com/ziebam), [vitest](https://g
 
 There are many more PRs currently in progress to do just the same :pray: Great work by the community here.
 
-# Contributions / Improvements
+## Contributions / Improvements
 
-## Storybook
+### Storybook
 
 The [Storybook](https://storybook.js.org/) team have been working closely with the e18e community for some time now, dedicating huge amounts of time to improving the performance and install footprint for everyone.
 
@@ -96,7 +96,7 @@ We would love to see this in more projects! You can get inspiration from [the PR
 
 This has all been great to see and will hopefully lead to other large projects making similar efforts! Definitely some big wins ahead :raised_hands:
 
-## nx
+### nx
 
 The folks over at [nx](https://github.com/nrwl/nx/) have been incredibly active with the e18e community. They are definitely on the same page and have been moving fast to work with the community to land many improvements.
 
@@ -110,7 +110,7 @@ Just a few examples of the improvements made:
 
 These are all improving the CPU performance of nx and cutting huge subtrees out of the dependency tree at the same time.
 
-## changesets
+### changesets
 
 The [changesets](https://github.com/changesets/changesets) project recently started collaborating directly with the e18e community and we've already seen a good amount of optimisations contributed.
 
@@ -120,7 +120,7 @@ It is awesome to see the maintainers of a large project working so closely with 
 
 Big thanks to [@bluwyoo](https://x.com/bluwyoo) and [@andaristrake](https://x.com/andaristrake) for getting this setup!
 
-## jimp
+### jimp
 
 [jimp](https://github.com/jimp-dev/jimp), an image manipulation library, has reduced their package size by an impressive amount:
 
@@ -129,7 +129,7 @@ Big thanks to [@bluwyoo](https://x.com/bluwyoo) and [@andaristrake](https://x.co
 
 This is awesome work :raised_hands:
 
-# Bonus: ViteConf
+## Bonus: ViteConf
 
 [ViteConf](https://viteconf.org/) happened recently and had some amazing talks across all topics.
 
@@ -137,6 +137,6 @@ While it didn't happen in September, it still deserves a mention thanks to how m
 
 Our own Bjorn did an excellent talk on performance ([watch here](https://viteconf.org/24/replay/performance)). Similarly, the great people at [Storybook](https://storybook.js.org/) explained a lot of their efforts to reduce their install footprint and how they've collaborated with the e18e community ([watch here](https://viteconf.org/24/replay/storybook)).
 
-# Get involved
+## Get involved
 
 If you want to help out, [join the discord](https://chat.e18e.dev). We'd love to have the help :pray:


### PR DESCRIPTION
A couple of posts have odd heading levels and should be one lower (i.e. `h2` instead of `h1`).