### PR TITLE
docs: remove X links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,7 +42,6 @@ export default defineConfig({
     socialLinks: [
       { icon: 'bluesky', link: 'https://bsky.app/profile/e18e.dev' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@e18e' },
-      { icon: 'twitter', link: 'https://twitter.com/e18e_dev' },
       { icon: 'discord', link: 'https://chat.e18e.dev' },
       { icon: 'github', link: 'https://github.com/e18e/e18e' },
     ],
@@ -78,10 +77,6 @@ export default defineConfig({
               {
                 text: 'Mastodon',
                 link: 'https://elk.zone/m.webtoo.ls/@e18e',
-              },
-              {
-                text: 'Twitter',
-                link: 'https://twitter.com/e18e_dev',
               },
               {
                 text: 'Discord Chat',


### PR DESCRIPTION
In just a few days, the [e18e's Bluesky account](https://bsky.app/profile/e18e.dev) is about to have the same number of followers than the X one.

I think we should focus our efforts there, and the X one is no longer a good tool to reach other folks.

This PR removes the X links and points people to the Bluesky profile instead (that is public and can be viewed without a Bluesky account). We should also remove the X link from the e18e GitHub org.