### PR TITLE
chore: pause mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Currently, there are three main areas of focus:
 - [speedup](https://e18e.dev/guide/speedup) - speeding up parts of the ecosystem many of us depend on.
 - [levelup](https://e18e.dev/guide/levelup) - documenting and providing modern, lighter alternatives to established tools and libraries we all regularly use.
 
+### e18e on Social
+
+Connect with us at the [e18e.dev bluesky account](https://bsky.app/profile/e18e.dev) to discuss with others and stay up-to-date on the cool stuff happening in the community!
+
+You can also find us in Mastodon and the fediverse at our bridged [@e18e.dev@bsky.brid.gy](https://m.webtoo.ls/@e18e.dev@bsky.brid.gy) account.
+
 ## Contributing
 
 See [Contributing Guide](https://github.com/e18e/e18e/blob/main/CONTRIBUTING.md).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -41,7 +41,6 @@ export default defineConfig({
 
     socialLinks: [
       { icon: 'bluesky', link: 'https://bsky.app/profile/e18e.dev' },
-      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@e18e' },
       { icon: 'discord', link: 'https://chat.e18e.dev' },
       { icon: 'github', link: 'https://github.com/e18e/e18e' },
     ],
@@ -73,10 +72,6 @@ export default defineConfig({
               {
                 text: 'Bluesky',
                 link: 'https://bsky.app/profile/e18e.dev',
-              },
-              {
-                text: 'Mastodon',
-                link: 'https://elk.zone/m.webtoo.ls/@e18e',
               },
               {
                 text: 'Discord Chat',

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -8,6 +8,8 @@ and much more.
 Our aim is to provide a space for contributions, ideas and knowledge sharing around the importance of performance across the ecosystem. Hopefully, with this collaboration, we can improve visibility of the impact of things like
 dependency choices. Join us at the [e18e Discord Server](https://chat.e18e.dev) to connect with other like-minded devs.
 
+Follow us at the [e18e.dev bluesky account](https://bsky.app/profile/e18e.dev) to discuss with others and stay up-to-date on the cool stuff happening in the community! You can also find us in Mastodon and the fediverse at our bridged [@e18e.dev@bsky.brid.gy](https://m.webtoo.ls/@e18e.dev@bsky.brid.gy) account.
+
 Currently, there are three main areas of focus:
 
 - [cleanup](./cleanup.md) - cleaning up dependency trees and modernizing popular tools and libraries across the ecosystem.


### PR DESCRIPTION
We decided to remove [links to X](https://github.com/e18e/e18e/pull/35) a month ago after seeing we had a better channel to connect with the community in bluesky (we [announced it in X here](https://x.com/e18e_dev/status/1854507220085436711)). The [e18e.dev bluesky] account now has 1.3K followers after a month, ~50% more than we got in X after half a year. There has been a spike in activity in the [e18e discord](https://chat.e18e.dev) due to new folks who joined as part of this new movement.

This would have been enough of a reason to focus on bluesky, but on top of that, many folks in our community had their own personal reasons to get out of X.

Several of us care about Mastodon. But the [e18e Mastodon account](https://elk.zone/m.webtoo.ls/@e18e) has 120 followers after half a year, and we don't see more interactions than a couple of reposts when we post the e18e blog posts. We have been trying to find someone in the e18e community who wants to help us with our Mastodon presence. Or anyone in Mastodon who would like to join our community and help. We have sent messages in Discord and [a direct CTA from the Mastodon account](https://elk.zone/m.webtoo.ls/@e18e/113594833636933822):
> Hey! We're looking for someone from the [e18e.dev](https://e18e.dev/) community (or someone who would like to join us in our push for leaner and more performant JavasScript packages) to help us with our social presence in Mastodon. Please join [chat.e18e.dev](https://chat.e18e.dev/) to discuss this if you're interested.

The post above had zero comments, and nobody stepped up. I also tried tagging some folks directly but have yet to be successful. We should leave the CTA message in Mastodon and pause our presence until someone is passionate enough to get involved.

This PR temporarily removes the links to Mastodon from the [e18e docs](https://e18e.dev).

I also followed [ap.brid.gy](https://bsky.app/profile/ap.brid.gy) from the e18e account, so folks in Mastodon can follow our bluesky account now by following `@e18e.dev@bsky.brid.gy` in Mastodon. Learn more at [fed.brid.gy](https://fed.brid.gy/). The PR also adds a note in the docs to guide Mastodon users to be able to keep following the active e18e account.