### PR TITLE
add dependents tool to cleanup section

### DIFF
--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -132,7 +132,7 @@ The fix here is often that we either:
 
 In this situation, it is worth looking for a lighter (and hopefully faster) alternative.
 
-::: tip Tip: Finding Dependents of a Packages
+### Tip: Finding Dependents of a Packages
 
 Once you identify a package that has potential for replacement, create an issue in our [cleanup-repository](https://github.com/es-tooling/ecosystem-cleanup) to inform other community members.
 
@@ -149,4 +149,3 @@ You can post the list as Markdown in the GitHub issue you created and then proce
 ```bash
 npx github:Fuzzyma/e18e-tools lodash -n 100 -q -o md  -U https://npm.devminer.xyz/registry > md-output.md
 ```
-:::

--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -136,7 +136,7 @@ In this situation, it is worth looking for a lighter (and hopefully faster) alte
 
 Once you identify a package that has potential for replacement, create an issue in our [cleanup-repository](https://github.com/es-tooling/ecosystem-cleanup) to inform other community members.
 
-Next, use[fuzzymas tool](https://github.com/fuzzyma/e18e-tools) to find the dependents of the package. You can find documentation on how to use the tool in its README.
+Next, use [fuzzymas tool](https://github.com/fuzzyma/e18e-tools) to find the dependents of the package. You can find documentation on how to use the tool in its README.
 
 Here’s an example that displays the top 100 dependents of `lodash`:
 

--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -132,7 +132,7 @@ The fix here is often that we either:
 
 In this situation, it is worth looking for a lighter (and hopefully faster) alternative.
 
-### Finding Other Dependents of Potential Packages
+::: tip Tip: Finding Dependents of a Packages
 
 Once you identify a package that has potential for replacement, create an issue in our [cleanup-repository](https://github.com/es-tooling/ecosystem-cleanup) to inform other community members.
 
@@ -149,5 +149,4 @@ You can post the list as Markdown in the GitHub issue you created and then proce
 ```bash
 npx github:Fuzzyma/e18e-tools lodash -n 100 -q -o md  -U https://npm.devminer.xyz/registry > md-output.md
 ```
-
-
+:::

--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -131,3 +131,23 @@ The fix here is often that we either:
 - Move to a dependency which is leaner and is more focused.
 
 In this situation, it is worth looking for a lighter (and hopefully faster) alternative.
+
+### Finding Other Dependents of Potential Packages
+
+Once you identify a package that has potential for replacement, create an issue in our [cleanup-repository](https://github.com/es-tooling/ecosystem-cleanup) to inform other community members.
+
+Next, use[fuzzymas tool](https://github.com/fuzzyma/e18e-tools) to find the dependents of the package. You can find documentation on how to use the tool in its README.
+
+Here’s an example that displays the top 100 dependents of `lodash`:
+
+```bash
+npx github:Fuzzyma/e18e-tools lodash -n 100 -U https://npm.devminer.xyz/registry
+```
+
+You can post the list as Markdown in the GitHub issue you created and then proceed to raise PRs for the affected projects:
+
+```bash
+npx github:Fuzzyma/e18e-tools lodash -n 100 -q -o md  -U https://npm.devminer.xyz/registry > md-output.md
+```
+
+


### PR DESCRIPTION
Someone in our discord requested to add the tool to the cleanup section of the docs: https://discord.com/channels/1227627367204257852/1227653370945474590/1317529015191339009

Not a huge writer myself but I hope this will do.