### PR TITLE
chore: bump node version on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "docs/.vitepress/dist"
 command = "pnpm run build"
 
 [build.environment]
-NODE_VERSION = "20"
+NODE_VERSION = "22"
 NODE_OPTIONS = "--max_old_space_size=4096"
 
 [functions]


### PR DESCRIPTION
Since node version 22 is stable now, we may use node version 22 here.