### PR TITLE
docs: update ecosystem-issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 The e18e (Ecosystem Performance) project is an initiative to bring together the groups and individuals who are passionate about improving performance of the JavaScript ecosystem.
 
-Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/43081j/ecosystem-cleanup) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/), and much more.
+Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/e18e/ecosystem-issues) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/), and much more.
 
 Our aim is to provide a space for contributions, ideas and knowledge sharing around the importance of performance across the ecosystem. Hopefully, with this collaboration, we can improve visibility of the impact of things like dependency choices. Join us at the [e18e Discord Server](https://chat.e18e.dev) to connect with other like-minded devs.
 

--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -4,7 +4,7 @@ The JavaScript ecosystem has grown massively over the years, in good and bad way
 
 Much of this is in the form of packages which are redundant, bloated or have since fallen out of active maintenance.
 
-A good example of the current efforts to clean our packages up, is [es-tooling/ecosystem-cleanup](https://github.com/es-tooling/ecosystem-cleanup). This project aims to drive contributions upstream to popular open-source projects. The project aims to:
+The e18e community maintains [e18e/ecosystem-issues](https://github.com/e18e/ecosystem-issues), which aims to drive contributions upstream to popular open-source projects, including:
 
 - Modernize existing packages
 - Migrate from redundant packages
@@ -12,7 +12,7 @@ A good example of the current efforts to clean our packages up, is [es-tooling/e
 - Migrate to lighter and/or faster alternatives
 
 ::: info Jump into action!
-The es-tooling community maintains a list of [open opportunities in the ecosystem-cleanup repo](https://github.com/43081j/ecosystem-cleanup/issues). After reading this guide, check out these issues for ideas to improve popular packages. And if you do research and find other places we can clean up a dependency tree, or speed it up, please do open some tracking issues in the cleanup repo, so you give others good starting points to get involved.
+Check out the list of [open opportunities in the ecosystem-issues repo](https://github.com/e18e/ecosystem-issues/issues). After reading this guide, check out these issues for ideas to improve popular packages. And if you do research and find other places we can clean up a dependency tree, or speed it up, please do open some tracking issues in the cleanup repo, so you give others good starting points to get involved.
 
 We can have a bigger effect working together. Join the [e18e Discord server](https://chat.e18e.dev) to connect with others to share your wins or get help along the way!
 :::
@@ -134,7 +134,7 @@ In this situation, it is worth looking for a lighter (and hopefully faster) alte
 
 ### Tip: Finding Dependents of a Packages
 
-Once you identify a package that has potential for replacement, create an issue in our [cleanup-repository](https://github.com/es-tooling/ecosystem-cleanup) to inform other community members.
+Once you identify a package that has potential for replacement, create an issue in our [cleanup-repository](https://github.com/e18e/ecosystem-issues) to inform other community members.
 
 Next, use [fuzzymas tool](https://github.com/fuzzyma/e18e-tools) to find the dependents of the package. You can find documentation on how to use the tool in its README.
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,7 +2,7 @@
 
 The e18e project is an initiative to bring together the groups and individuals who are passionate about improving performance of the JavaScript ecosystem.
 
-Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/43081j/ecosystem-cleanup) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/),
+Many ongoing efforts are already happening in this space, from [dependency tree cleanups](https://github.com/e18e/ecosystem-issues) to [performance optimizations](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/),
 and much more.
 
 Our aim is to provide a space for contributions, ideas and knowledge sharing around the importance of performance across the ecosystem. Hopefully, with this collaboration, we can improve visibility of the impact of things like

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -4,7 +4,7 @@
 
 |  | Description |
 | -- | -- |
-| [JS ecosystem cleanup](https://github.com/43081j/ecosystem-cleanup) | Efforts to provide a cleaner dependency tree in the JS ecosystem |
+| [JS ecosystem cleanup](https://github.com/e18e/ecosystem-issues) | Efforts to provide a cleaner dependency tree in the JS ecosystem |
 | [Tinylibs](https://github.com/tinylibs) | A place for tiny and minimal libraries |
 | [unjs](https://github.com/unjs/) | Purpose-built, high-quality JavaScript utilities, libraries, and tools |
 | [es-tooling](https://github.com/es-tooling/) | A collection of tooling for the JS ecosystem |


### PR DESCRIPTION
Update link to new repo url: https://github.com/e18e/ecosystem-issues

I also updated the cleanup guide a bit so it makes more sense as an official project.

I didn't update the links in the blog posts to preserve its meaning, but the links should still redirect. But we could update them if we want to.