### PR TITLE
docs: simplify nav bar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,32 +64,7 @@ export default defineConfig({
 
     nav: [
       { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
-      {
-        text: 'Resources',
-        items: [
-          { text: 'Blog', link: '/blog' },
-          {
-            items: [
-              {
-                text: 'Bluesky',
-                link: 'https://bsky.app/profile/e18e.dev',
-              },
-              {
-                text: 'Mastodon',
-                link: 'https://elk.zone/m.webtoo.ls/@e18e',
-              },
-              {
-                text: 'Discord Chat',
-                link: 'https://chat.e18e.dev',
-              },
-              {
-                text: 'Contributing',
-                link: 'https://github.com/e18e/e18e/blob/main/CONTRIBUTING.md',
-              },
-            ],
-          },
-        ],
-      },
+      { text: 'Blog', link: '/blog' },
     ],
 
     sidebar: {


### PR DESCRIPTION
- Moved `Blog` to top level so it's more visible as we have many content there too.
- Removed the `Resources` dropdown completely as the social links are already shown on desktop, or the dot-dot-dot on mobile.
- Also removed the `Contributing` link as there's not really much content to show: https://github.com/e18e/e18e/blob/main/CONTRIBUTING.md. I think the guide docs already covers the contributing topics.