### PR TITLE
docs: typo

### DIFF
--- a/docs/guide/cleanup.md
+++ b/docs/guide/cleanup.md
@@ -101,7 +101,7 @@ Common things to check:
 
 - node `engines` specifying a node version low enough that this dependency supports (and alternatives don't).
 - there is no known alternative (good opportunity to make one!).
-- every deep dependency in the subtree is necessary (in many cases the tree may be deep but for good reason, to share modules, etc).
+- every deep dependency in the subtree is necessary (in many cases the tree may be deep but for good reason, to share modules, etc.).
 
 If it is indeed replaceable, you should find an alternative. Good resources for that are:
 

--- a/docs/guide/speedup.md
+++ b/docs/guide/speedup.md
@@ -41,6 +41,6 @@ Prefer using non-async [iterators](https://developer.mozilla.org/en-US/docs/Web/
 
 ### Avoid chaining array methods
 
-Chaining array methods like `map`, `filter`, `reduce`, etc leads to many intermediate arrays being created and disposed, causing more work for the garbage collector. Each chain also leads to an extra iteration, which can be more times than needed.
+Chaining array methods like `map`, `filter`, `reduce`, etc. leads to many intermediate arrays being created and disposed, causing more work for the garbage collector. Each chain also leads to an extra iteration, which can be more times than needed.
 
 Prefer using [`for` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for), [`for...in` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in), and[`for...of` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), or a single chain method only to prevent the caveats above.


### PR DESCRIPTION
The correct abbreviation is "etc." with a period at the end.