### PR TITLE
docs: add more packages to replacements guide

### DIFF
--- a/docs/guide/replacement-guides/eslint-plugin-es.md
+++ b/docs/guide/replacement-guides/eslint-plugin-es.md
@@ -2,7 +2,7 @@
 
 ## `eslint-plugin-es-x`
 
-eslint-plugin-es-x is a direct fork which is actively maintained. It has new features, bugfixes and updated dependencies.
+[eslint-plugin-es-x](https://github.com/eslint-community/eslint-plugin-es-x) is a direct fork which is actively maintained. It has new features, bugfixes and updated dependencies.
 
 ```js
 import pluginESx from "eslint-plugin-es-x" // [!code ++]
@@ -26,7 +26,7 @@ module.exports = {
     'es-x'   // [!code ++]
   ],
   rules: {
-    // 'es/no-regexp-lookbehind-assertions': 'error', // [!code --]
+    'es/no-regexp-lookbehind-assertions': 'error', // [!code --]
     'es-x/no-regexp-lookbehind-assertions': 'error', // [!code ++]
   }
 }

--- a/docs/guide/replacement-guides/eslint-plugin-es.md
+++ b/docs/guide/replacement-guides/eslint-plugin-es.md
@@ -1,0 +1,33 @@
+# Replacements for `eslint-plugin-es`
+
+## `eslint-plugin-es-x`
+
+eslint-plugin-es-x is a direct fork which is actively maintained. It has new features, bugfixes and updated dependencies.
+
+```js
+import pluginESx from "eslint-plugin-es-x" // [!code ++]
+
+export default [
+    pluginESx.configs['flat/restrict-to-es2018'],
+]
+```
+
+If you're using a legacy config format:
+
+```js
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:es/restrict-to-es2018', // [!code --]
+    'plugin:es-x/restrict-to-es2018', // [!code ++]
+  ],
+  plugins: [
+    'es',    // [!code --]
+    'es-x'   // [!code ++]
+  ],
+  rules: {
+    // 'es/no-regexp-lookbehind-assertions': 'error', // [!code --]
+    'es-x/no-regexp-lookbehind-assertions': 'error', // [!code ++]
+  }
+}
+```

--- a/docs/guide/replacement-guides/eslint-plugin-es.md
+++ b/docs/guide/replacement-guides/eslint-plugin-es.md
@@ -5,10 +5,30 @@
 [eslint-plugin-es-x](https://github.com/eslint-community/eslint-plugin-es-x) is a direct fork which is actively maintained. It has new features, bugfixes and updated dependencies.
 
 ```js
+import { FlatCompat } from '@eslint/eslintrc' // [!code --]
+import pluginES from 'eslint-plugin-es' // [!code --]
 import pluginESx from 'eslint-plugin-es-x' // [!code ++]
 
+const compat = new FlatCompat() // [!code --]
+
 export default [
-  pluginESx.configs['flat/restrict-to-es2018'], // [!code ++]
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+    },
+    plugins: {
+      'es': pluginES, // [!code --]
+      'es-x': pluginESx, // [!code ++]
+    },
+    rules: {
+      'es/no-regexp-lookbehind-assertions': 'error', // [!code --]
+      'es-x/no-regexp-lookbehind-assertions': 'error' // [!code ++]
+    },
+  },
+
+  ...compat.extends('plugin:es/restrict-to-es2018'), // [!code --]
+  pluginESx.configs['flat/restrict-to-es2018'],
 ]
 ```
 

--- a/docs/guide/replacement-guides/eslint-plugin-es.md
+++ b/docs/guide/replacement-guides/eslint-plugin-es.md
@@ -8,7 +8,7 @@ eslint-plugin-es-x is a direct fork which is actively maintained. It has new fea
 import pluginESx from "eslint-plugin-es-x" // [!code ++]
 
 export default [
-    pluginESx.configs['flat/restrict-to-es2018'],
+    pluginESx.configs['flat/restrict-to-es2018'], // [!code ++]
 ]
 ```
 

--- a/docs/guide/replacement-guides/eslint-plugin-es.md
+++ b/docs/guide/replacement-guides/eslint-plugin-es.md
@@ -28,7 +28,7 @@ export default [
   },
 
   ...compat.extends('plugin:es/restrict-to-es2018'), // [!code --]
-  pluginESx.configs['flat/restrict-to-es2018'],
+  pluginESx.configs['flat/restrict-to-es2018'], // [!code ++]
 ]
 ```
 

--- a/docs/guide/replacement-guides/eslint-plugin-es.md
+++ b/docs/guide/replacement-guides/eslint-plugin-es.md
@@ -5,10 +5,10 @@
 [eslint-plugin-es-x](https://github.com/eslint-community/eslint-plugin-es-x) is a direct fork which is actively maintained. It has new features, bugfixes and updated dependencies.
 
 ```js
-import pluginESx from "eslint-plugin-es-x" // [!code ++]
+import pluginESx from 'eslint-plugin-es-x' // [!code ++]
 
 export default [
-    pluginESx.configs['flat/restrict-to-es2018'], // [!code ++]
+  pluginESx.configs['flat/restrict-to-es2018'], // [!code ++]
 ]
 ```
 
@@ -22,8 +22,8 @@ module.exports = {
     'plugin:es-x/restrict-to-es2018', // [!code ++]
   ],
   plugins: [
-    'es',    // [!code --]
-    'es-x'   // [!code ++]
+    'es', // [!code --]
+    'es-x' // [!code ++]
   ],
   rules: {
     'es/no-regexp-lookbehind-assertions': 'error', // [!code --]

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -5,17 +5,20 @@
 [`@eslint-community/eslint-plugin-eslint-comments`](https://github.com/eslint-community/eslint-plugin-eslint-comments) is the actively maintained successor with updated dependencies, flat config support, and continued development.
 
 ```js
-import comments from '@eslint-community/eslint-plugin-eslint-comments/configs' // [!code ++]
-import js from '@eslint/js'
+import commentsCommunity from '@eslint-community/eslint-plugin-eslint-comments/configs' // [!code ++]
+import eslintComments from 'eslint-plugin-eslint-comments' // [!code --]
 
 export default [
-  js.configs.recommended,
-  comments.recommended, // [!code ++]
+  commentsCommunity.recommended, // [!code ++]
   {
+    plugins: {
+      'eslint-comments': eslintComments, // [!code --]
+    },
     rules: {
+      'eslint-comments/no-unused-disable': 'error',         // [!code --]
       '@eslint-community/eslint-comments/no-unused-disable': 'error', // [!code ++]
     }
-  },
+  }
 ]
 ```
 

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -5,8 +5,9 @@
 [`@eslint-community/eslint-plugin-eslint-comments`](https://github.com/eslint-community/eslint-plugin-eslint-comments) is the actively maintained successor with updated dependencies, flat config support, and continued development.
 
 ```js
-import commentsCommunity from '@eslint-community/eslint-plugin-eslint-comments/configs' // [!code ++]
 import eslintComments from 'eslint-plugin-eslint-comments' // [!code --]
+// eslint-disable-next-line perfectionist/sort-imports
+import commentsCommunity from '@eslint-community/eslint-plugin-eslint-comments/configs' // [!code ++]
 
 export default [
   commentsCommunity.recommended, // [!code ++]

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -15,7 +15,7 @@ export default [
       'eslint-comments': eslintComments, // [!code --]
     },
     rules: {
-      'eslint-comments/no-unused-disable': 'error',         // [!code --]
+      'eslint-comments/no-unused-disable': 'error', // [!code --]
       '@eslint-community/eslint-comments/no-unused-disable': 'error', // [!code ++]
     }
   }
@@ -26,14 +26,14 @@ If you're using a legacy config format:
 
 ```js
 module.exports = {
-    extends: [
-        "eslint:recommended",
-        "plugin:eslint-comments/recommended", // [!code --]
-        "plugin:@eslint-community/eslint-comments/recommended" // [!code ++]
-    ],
-    rules: {
-        "eslint-comments/no-unused-disable": "error", // [!code --]
-        "@eslint-community/eslint-comments/no-unused-disable": "error" // [!code ++]
-    }
+  extends: [
+    'eslint:recommended',
+    'plugin:eslint-comments/recommended', // [!code --]
+    'plugin:@eslint-community/eslint-comments/recommended' // [!code ++]
+  ],
+  rules: {
+    'eslint-comments/no-unused-disable': 'error', // [!code --]
+    '@eslint-community/eslint-comments/no-unused-disable': 'error' // [!code ++]
+  }
 }
 ```

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -1,0 +1,36 @@
+Replacements for `eslint-plugin-eslint-comments`
+
+## `@eslint-community/eslint-plugin-eslint-comments`
+
+[`@eslint-community/eslint-plugin-eslint-comments`](https://github.com/eslint-community/eslint-plugin-eslint-comments) is the actively maintained successor with updated dependencies, flat config support, and continued development.
+
+```js
+import js from "@eslint/js"
+import comments from "@eslint-community/eslint-plugin-eslint-comments/configs" // [!code ++]
+
+export default [
+    js.configs.recommended,
+    comments.recommended, // [!code ++]
+    {
+        rules: {
+            "@eslint-community/eslint-comments/no-unused-disable": "error", // [!code ++]
+        }
+    },
+]
+```
+
+If you're using a legacy config format:
+
+```js
+module.exports = {
+    extends: [
+        "eslint:recommended",
+        "plugin:eslint-comments/recommended", // [!code --]
+        "plugin:@eslint-community/eslint-comments/recommended" // [!code ++]
+    ],
+    rules: {
+        // "eslint-comments/no-unused-disable": "error" // [!code --]
+        "@eslint-community/eslint-comments/no-unused-disable": "error" // [!code ++]
+    }
+}
+```

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -29,7 +29,7 @@ module.exports = {
         "plugin:@eslint-community/eslint-comments/recommended" // [!code ++]
     ],
     rules: {
-        // "eslint-comments/no-unused-disable": "error" // [!code --]
+        "eslint-comments/no-unused-disable": "error" // [!code --]
         "@eslint-community/eslint-comments/no-unused-disable": "error" // [!code ++]
     }
 }

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -6,7 +6,6 @@
 
 ```js
 import eslintComments from 'eslint-plugin-eslint-comments' // [!code --]
-// eslint-disable-next-line perfectionist/sort-imports
 import commentsCommunity from '@eslint-community/eslint-plugin-eslint-comments/configs' // [!code ++]
 
 export default [

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -5,17 +5,17 @@
 [`@eslint-community/eslint-plugin-eslint-comments`](https://github.com/eslint-community/eslint-plugin-eslint-comments) is the actively maintained successor with updated dependencies, flat config support, and continued development.
 
 ```js
-import js from "@eslint/js"
-import comments from "@eslint-community/eslint-plugin-eslint-comments/configs" // [!code ++]
+import comments from '@eslint-community/eslint-plugin-eslint-comments/configs' // [!code ++]
+import js from '@eslint/js'
 
 export default [
-    js.configs.recommended,
-    comments.recommended, // [!code ++]
-    {
-        rules: {
-            "@eslint-community/eslint-comments/no-unused-disable": "error", // [!code ++]
-        }
-    },
+  js.configs.recommended,
+  comments.recommended, // [!code ++]
+  {
+    rules: {
+      '@eslint-community/eslint-comments/no-unused-disable': 'error', // [!code ++]
+    }
+  },
 ]
 ```
 

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -32,7 +32,7 @@ module.exports = {
         "plugin:@eslint-community/eslint-comments/recommended" // [!code ++]
     ],
     rules: {
-        "eslint-comments/no-unused-disable": "error" // [!code --]
+        "eslint-comments/no-unused-disable": "error", // [!code --]
         "@eslint-community/eslint-comments/no-unused-disable": "error" // [!code ++]
     }
 }

--- a/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
+++ b/docs/guide/replacement-guides/eslint-plugin-eslint-comments.md
@@ -1,4 +1,4 @@
-Replacements for `eslint-plugin-eslint-comments`
+# Replacements for `eslint-plugin-eslint-comments`
 
 ## `@eslint-community/eslint-plugin-eslint-comments`
 

--- a/docs/guide/replacement-guides/npm-run-all.md
+++ b/docs/guide/replacement-guides/npm-run-all.md
@@ -23,10 +23,11 @@ The commands remain the same: `npm-run-all`, `run-s`, and `run-p`.
 Another option is [concurrently](https://github.com/open-cli-tools/concurrently), which focuses on running scripts in parallel with colored output and process control. It uses a slightly different syntax but works well for replacing the `--parallel` use case.
 
 ```json
+/* eslint-disable jsonc/no-dupe-keys */
 {
   "scripts": {
-    "dev:npm-run-all": "npm-run-all --parallel \"watch-*\" start", // [!code --]
-    "dev:concurrently": "concurrently \"npm:watch-*\" \"npm:start\"" // [!code ++]
+    "dev": "npm-run-all --parallel \"watch-*\" start", // [!code --]
+    "dev": "concurrently \"npm:watch-*\" \"npm:start\"" // [!code ++]
   }
 }
 ```

--- a/docs/guide/replacement-guides/npm-run-all.md
+++ b/docs/guide/replacement-guides/npm-run-all.md
@@ -4,7 +4,7 @@
 
 [npm-run-all2](https://github.com/bcomnes/npm-run-all2) is an actively maintained fork with important fixes, dependency updates. The CLI is fully compatible, so you can migrate by replacing the package name.
 
-```
+```json
 {
   "scripts": {
     "build": "npm-run-all clean lint compile"
@@ -18,7 +18,7 @@ The commands remain the same: `npm-run-all`, `run-s`, and `run-p`.
 
 Another option is [concurrently](https://github.com/open-cli-tools/concurrently), which focuses on running scripts in parallel with colored output and process control. It uses a slightly different syntax but works well for replacing the `--parallel` use case.
 
-```
+```json
 {
   "scripts": {
     "dev": "concurrently \"npm:watch-*\" \"npm:start\""
@@ -30,7 +30,7 @@ Another option is [concurrently](https://github.com/open-cli-tools/concurrently)
 
 For more advanced workflows, consider [Wireit](https://github.com/google/wireit). It integrates directly into `package.json` to add caching, dependency graphs, watch mode, and incremental builds. Unlike `npm-run-all`, Wireit upgrades your existing `npm run` experience instead of providing a separate CLI.
 
-```
+```json
 {
   "scripts": {
     "build": "wireit",

--- a/docs/guide/replacement-guides/npm-run-all.md
+++ b/docs/guide/replacement-guides/npm-run-all.md
@@ -19,7 +19,6 @@ The commands remain the same: `npm-run-all`, `run-s`, and `run-p`.
 Another option is [concurrently](https://github.com/open-cli-tools/concurrently), which focuses on running scripts in parallel with colored output and process control. It uses a slightly different syntax but works well for replacing the `--parallel` use case.
 
 ```json
-/* eslint-disable jsonc/no-dupe-keys */
 {
   "scripts": {
     "dev": "npm-run-all --parallel \"watch-*\" start", // [!code --]

--- a/docs/guide/replacement-guides/npm-run-all.md
+++ b/docs/guide/replacement-guides/npm-run-all.md
@@ -6,12 +6,8 @@
 
 ```json
 {
-  "devDependencies": {
-    "npm-run-all": "^X.Y.Z", // [!code --]
-    "npm-run-all2": "^X.Y.Z" // [!code ++]
-  },
   "scripts": {
-    "build": "npm-run-all clean lint compile"
+    "build": "npm-run-all clean lint compile" // (scripts remains the same)
   }
 }
 ```

--- a/docs/guide/replacement-guides/npm-run-all.md
+++ b/docs/guide/replacement-guides/npm-run-all.md
@@ -1,0 +1,57 @@
+# Replacements for `npm-run-all`
+
+## `npm-run-all2`
+
+[npm-run-all2](https://github.com/bcomnes/npm-run-all2) is an actively maintained fork with important fixes, dependency updates. The CLI is fully compatible, so you can migrate by replacing the package name.
+
+```
+{
+  "scripts": {
+    "build": "npm-run-all clean lint compile"
+  }
+}
+```
+
+The commands remain the same: `npm-run-all`, `run-s`, and `run-p`.
+
+## `concurrently`
+
+Another option is [concurrently](https://github.com/open-cli-tools/concurrently), which focuses on running scripts in parallel with colored output and process control. It uses a slightly different syntax but works well for replacing the `--parallel` use case.
+
+```
+{
+  "scripts": {
+    "dev": "concurrently \"npm:watch-*\" \"npm:start\""
+  }
+}
+```
+
+## `Wireit`
+
+For more advanced workflows, consider [Wireit](https://github.com/google/wireit). It integrates directly into `package.json` to add caching, dependency graphs, watch mode, and incremental builds. Unlike `npm-run-all`, Wireit upgrades your existing `npm run` experience instead of providing a separate CLI.
+
+```
+{
+  "scripts": {
+    "build": "wireit",
+    "compile": "wireit",
+    "bundle": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": ["compile", "bundle"]
+    },
+    "compile": {
+      "command": "tsc",
+      "files": ["src/**/*.ts"],
+      "output": ["lib/**"]
+    },
+    "bundle": {
+      "command": "rollup -c",
+      "dependencies": ["compile"],
+      "files": ["rollup.config.js"],
+      "output": ["dist/**"]
+    }
+  }
+}
+```

--- a/docs/guide/replacement-guides/npm-run-all.md
+++ b/docs/guide/replacement-guides/npm-run-all.md
@@ -2,10 +2,14 @@
 
 ## `npm-run-all2`
 
-[npm-run-all2](https://github.com/bcomnes/npm-run-all2) is an actively maintained fork with important fixes, dependency updates. The CLI is fully compatible, so you can migrate by replacing the package name.
+[npm-run-all2](https://github.com/bcomnes/npm-run-all2) is an actively maintained fork with important fixes, dependency updates.
 
 ```json
 {
+  "devDependencies": {
+    "npm-run-all": "^X.Y.Z", // [!code --]
+    "npm-run-all2": "^X.Y.Z" // [!code ++]
+  },
   "scripts": {
     "build": "npm-run-all clean lint compile"
   }
@@ -21,7 +25,8 @@ Another option is [concurrently](https://github.com/open-cli-tools/concurrently)
 ```json
 {
   "scripts": {
-    "dev": "concurrently \"npm:watch-*\" \"npm:start\""
+    "dev:npm-run-all": "npm-run-all --parallel \"watch-*\" start", // [!code --]
+    "dev:concurrently": "concurrently \"npm:watch-*\" \"npm:start\"" // [!code ++]
   }
 }
 ```

--- a/docs/guide/replacement-guides/npm-run-all.md
+++ b/docs/guide/replacement-guides/npm-run-all.md
@@ -7,7 +7,7 @@
 ```json
 {
   "scripts": {
-    "build": "npm-run-all clean lint compile" // (scripts remains the same)
+    "build": "npm-run-all clean lint compile"
   }
 }
 ```

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -18,7 +18,7 @@ If you need to support Node.js 12 up to 14.13, you can use [`fs.rmdir`](https://
 
 ```js
 import rimraf from 'rimraf' // [!code --]
-import { rmdir } from 'node:fs/promises'
+import { rmdir } from 'node:fs/promises' // [!code ++]
 
 await rimraf('./dist') // [!code --]
 await rmdir('./dist', { recursive: true }) // [!code ++]
@@ -31,8 +31,6 @@ To replace `rimraf` inside npm scripts, you can run Node directly in eval mode:
 ```sh
 node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetries: process.platform === 'win32' ? 10 : 0 })"
 ```
-
----
 
 ## `premove`
 

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -5,11 +5,11 @@
 If you are using [`rimraf`](https://github.com/isaacs/rimraf) to remove files and directories, modern Node.js provides native alternatives. Since Node v14.14.0, [`fs.rm`](https://nodejs.org/api/fs.html#fspromisesrmpath-options) supports recursive deletion and works as a direct replacement.
 
 ```js
-import { rm } from 'node:fs/promises'; // [!code ++]
-import rimraf from 'rimraf';           // [!code --]
+import { rm } from 'node:fs/promises' // [!code ++]
+import rimraf from 'rimraf' // [!code --]
 
-await rimraf('./dist');                // [!code --]
-await rm('./dist', { recursive: true, force: true }); // [!code ++]
+await rimraf('./dist') // [!code --]
+await rm('./dist', { recursive: true, force: true }) // [!code ++]
 ```
 
 ## Node.js (older versions)
@@ -17,11 +17,11 @@ await rm('./dist', { recursive: true, force: true }); // [!code ++]
 If you need to support Node 12, you can use [`fs.rmdir`](https://nodejs.org/api/fs.html#fsrmdirpath-options-callback) with the recursive option. This option has been available since Node v12.10, but will print a deprecation warning in Node v14 and newer.
 
 ```js
-import { rmdir } from 'node:fs/promises';
-import rimraf from 'rimraf';           // [!code --]
+import { rmdir } from 'node:fs/promises'
+import rimraf from 'rimraf' // [!code --]
 
-await rimraf('./dist');                // [!code --]
-await rmdir('./dist', { recursive: true }); // [!code ++]
+await rimraf('./dist') // [!code --]
+await rmdir('./dist', { recursive: true }) // [!code ++]
 ```
 
 ## CLI usage

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -36,7 +36,7 @@ node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetri
 
 ## `premove`
 
-If you are on an older Node.js version (before v12.10) or you specifically need a CLI replacement, use [`premove`](https://github.com/lukeed/premove). It provides both an API and a CLI and works on Node.js v8 and newer.
+If you are on an older Node.js version (before v12.10) or you specifically need a CLI replacement, you can use [`premove`](https://github.com/lukeed/premove). It provides both an API and a CLI and works on Node.js v8 and newer.
 
 ```sh
 rimraf ./dist # [!code --]

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -14,7 +14,7 @@ await rm('./dist', { recursive: true, force: true }); // [!code ++]
 
 ## Node.js (older versions)
 
-If you need to support Node 12, you can use fs.rmdir with the recursive option. This option has been available since Node v12.10, but will print a deprecation warning in Node v14 and newer.
+If you need to support Node 12, you can use [`fs.rmdir`](https://nodejs.org/api/fs.html#fsrmdirpath-options-callback) with the recursive option. This option has been available since Node v12.10, but will print a deprecation warning in Node v14 and newer.
 
 ```js
 import { rmdir } from 'node:fs/promises';
@@ -36,7 +36,7 @@ node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetri
 
 ## `premove`
 
-For cases where you cannot rely on Node being available, use [`premove`](https://www.npmjs.com/package/premove). It includes a CLI and works on Node v8 and newer.
+For cases where you cannot rely on Node being available, use [`premove`](https://github.com/lukeed/premove). It includes a CLI and works on Node v8 and newer.
 
 ```sh
 premove ./dist

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -6,7 +6,6 @@ Node.js v14.14.0 and above provide a native alternative: [`fs.rm`](https://nodej
 
 ```js
 import rimraf from 'rimraf' // [!code --]
-// eslint-disable-next-line perfectionist/sort-imports
 import { rm } from 'node:fs/promises' // [!code ++]
 
 await rimraf('./dist') // [!code --]
@@ -19,7 +18,6 @@ If you need to support Node.js 12 up to 14.13, you can use [`fs.rmdir`](https://
 
 ```js
 import rimraf from 'rimraf' // [!code --]
-// eslint-disable-next-line perfectionist/sort-imports
 import { rmdir } from 'node:fs/promises'
 
 await rimraf('./dist') // [!code --]
@@ -41,7 +39,6 @@ node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetri
 If you are on an older Node.js version (before v12.10) or you specifically need a CLI replacement, you can use [`premove`](https://github.com/lukeed/premove). It provides both an API and a CLI and works on Node.js v8 and newer.
 
 ```json
-/* eslint-disable jsonc/no-dupe-keys */
 {
   "scripts": {
     "clean": "rimraf lib", // [!code --]

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -44,8 +44,8 @@ If you are on an older Node.js version (before v12.10) or you specifically need 
 /* eslint-disable jsonc/no-dupe-keys */
 {
   "scripts": {
-    "clean": "rimraf lib",   // [!code --]
-    "clean": "premove lib"  // [!code ++]
+    "clean": "rimraf lib", // [!code --]
+    "clean": "premove lib" // [!code ++]
   }
 }
 ```

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -1,0 +1,43 @@
+# Replacements for `rimraf`
+
+## Node.js
+
+If you are using [`rimraf`](https://github.com/isaacs/rimraf) to remove files and directories, modern Node.js provides native alternatives. Since Node v14.14.0, [`fs.rm`](https://nodejs.org/api/fs.html#fspromisesrmpath-options) supports recursive deletion and works as a direct replacement.
+
+```js
+import { rm } from 'node:fs/promises'; // [!code ++]
+import rimraf from 'rimraf';           // [!code --]
+
+await rimraf('./dist');                // [!code --]
+await rm('./dist', { recursive: true, force: true }); // [!code ++]
+```
+
+## Node.js (older versions)
+
+If you need to support Node 12, you can use fs.rmdir with the recursive option. This option has been available since Node v12.10, but will print a deprecation warning in Node v14 and newer.
+
+```js
+import { rmdir } from 'node:fs/promises';
+import rimraf from 'rimraf';           // [!code --]
+
+await rimraf('./dist');                // [!code --]
+await rmdir('./dist', { recursive: true }); // [!code ++]
+```
+
+## CLI usage
+
+To replace `rimraf` inside npm scripts, you can run Node directly in eval mode:
+
+```sh
+node -e "require('fs').rmSync('./dist', { recursive: true, force: true })"
+```
+
+---
+
+## `premove`
+
+For cases where you cannot rely on Node being available, use [`premove`](https://www.npmjs.com/package/premove). It includes a CLI and works on Node v8 and newer.
+
+```sh
+premove ./dist
+```

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -5,8 +5,9 @@
 Node.js v14.14.0 and above provide a native alternative: [`fs.rm`](https://nodejs.org/api/fs.html#fspromisesrmpath-options). It supports recursive deletion and works as a direct replacement.
 
 ```js
-import { rm } from 'node:fs/promises' // [!code ++]
 import rimraf from 'rimraf' // [!code --]
+// eslint-disable-next-line perfectionist/sort-imports
+import { rm } from 'node:fs/promises' // [!code ++]
 
 await rimraf('./dist') // [!code --]
 await rm('./dist', { recursive: true, force: true }) // [!code ++]
@@ -17,8 +18,9 @@ await rm('./dist', { recursive: true, force: true }) // [!code ++]
 If you need to support Node.js 12 up to 14.13, you can use [`fs.rmdir`](https://nodejs.org/api/fs.html#fsrmdirpath-options-callback) with the recursive option. This was added in Node v12.10.0, though it’s deprecated as of Node v14.
 
 ```js
-import { rmdir } from 'node:fs/promises'
 import rimraf from 'rimraf' // [!code --]
+// eslint-disable-next-line perfectionist/sort-imports
+import { rmdir } from 'node:fs/promises'
 
 await rimraf('./dist') // [!code --]
 await rmdir('./dist', { recursive: true }) // [!code ++]

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -2,7 +2,7 @@
 
 ## Node.js
 
-If you are using [`rimraf`](https://github.com/isaacs/rimraf) to remove files and directories, modern Node.js provides native alternatives. Since Node v14.14.0, [`fs.rm`](https://nodejs.org/api/fs.html#fspromisesrmpath-options) supports recursive deletion and works as a direct replacement.
+Node.js v14.14.0 and above provide a native alternative: [`fs.rm`](https://nodejs.org/api/fs.html#fspromisesrmpath-options). It supports recursive deletion and works as a direct replacement.
 
 ```js
 import { rm } from 'node:fs/promises' // [!code ++]
@@ -12,9 +12,9 @@ await rimraf('./dist') // [!code --]
 await rm('./dist', { recursive: true, force: true }) // [!code ++]
 ```
 
-## Node.js (older versions)
+## Node.js (before v14.14.0)
 
-If you need to support Node 12, you can use [`fs.rmdir`](https://nodejs.org/api/fs.html#fsrmdirpath-options-callback) with the recursive option. This option has been available since Node v12.10, but will print a deprecation warning in Node v14 and newer.
+If you need to support Node.js 12 up to 14.13, you can use [`fs.rmdir`](https://nodejs.org/api/fs.html#fsrmdirpath-options-callback) with the recursive option. This was added in Node v12.10.0, though it’s deprecated as of Node v14.
 
 ```js
 import { rmdir } from 'node:fs/promises'
@@ -39,5 +39,6 @@ node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetri
 For cases where you cannot rely on Node being available, use [`premove`](https://github.com/lukeed/premove). It includes a CLI and works on Node v8 and newer.
 
 ```sh
-premove ./dist
+rimraf ./dist       # [!code --]
+premove ./dist      # [!code ++]
 ```

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -29,7 +29,7 @@ await rmdir('./dist', { recursive: true }); // [!code ++]
 To replace `rimraf` inside npm scripts, you can run Node directly in eval mode:
 
 ```sh
-node -e "require('fs').rmSync('./dist', { recursive: true, force: true })"
+node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetries: process.platform === 'win32' ? 10 : 0 })"
 ```
 
 ---

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -36,9 +36,9 @@ node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetri
 
 ## `premove`
 
-For cases where you cannot rely on Node being available, use [`premove`](https://github.com/lukeed/premove). It includes a CLI and works on Node v8 and newer.
+If you are on an older Node.js version (before v12.10) or you specifically need a CLI replacement, use [`premove`](https://github.com/lukeed/premove). It provides both an API and a CLI and works on Node.js v8 and newer.
 
 ```sh
-rimraf ./dist       # [!code --]
-premove ./dist      # [!code ++]
+rimraf ./dist # [!code --]
+premove ./dist # [!code ++]
 ```

--- a/docs/guide/replacement-guides/rimraf.md
+++ b/docs/guide/replacement-guides/rimraf.md
@@ -40,7 +40,12 @@ node -e "require('fs').rmSync('./dist', { recursive: true, force: true, maxRetri
 
 If you are on an older Node.js version (before v12.10) or you specifically need a CLI replacement, you can use [`premove`](https://github.com/lukeed/premove). It provides both an API and a CLI and works on Node.js v8 and newer.
 
-```sh
-rimraf ./dist # [!code --]
-premove ./dist # [!code ++]
+```json
+/* eslint-disable jsonc/no-dupe-keys */
+{
+  "scripts": {
+    "clean": "rimraf lib",   // [!code --]
+    "clean": "premove lib"  // [!code ++]
+  }
+}
 ```

--- a/docs/guide/replacement-guides/strip-ansi.md
+++ b/docs/guide/replacement-guides/strip-ansi.md
@@ -5,8 +5,8 @@
 Added in v16.11.0, [util.stripVTControlCharacters](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) can be used to strip ANSI escape codes from a string.
 
 ```js
-import { stripVTControlCharacters } from 'node:util' // [!code ++]
 import stripAnsi from 'strip-ansi' // [!code --]
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
 
 console.log(stripAnsi('\u001B[4me18e\u001B[0m')) // [!code --]
 console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
@@ -17,8 +17,8 @@ console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
 Deno implements the Node `util` API, and also provides [`util.stripVTControlCharacters`](https://docs.deno.com/api/node/util/~/stripVTControlCharacters). The usage is identical:
 
 ```js
-import { stripVTControlCharacters } from 'node:util' // [!code ++]
 import stripAnsi from 'strip-ansi' // [!code --]
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
 
 console.log(stripAnsi('\u001B[4me18e\u001B[0m')) // [!code --]
 console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
@@ -31,8 +31,8 @@ console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
 Bun also implements Node’s [`util.stripVTControlCharacters`](https://bun.sh/reference/node/util/stripVTControlCharacters) through its Node compat layer:
 
 ```js
-import { stripVTControlCharacters } from 'node:util' // [!code ++]
 import stripAnsi from 'strip-ansi' // [!code --]
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
 
 console.log(stripAnsi('\u001B[1mHello\u001B[0m')) // [!code --]
 console.log(stripVTControlCharacters('\u001B[1mHello\u001B[0m')) // [!code ++]
@@ -43,8 +43,8 @@ console.log(stripVTControlCharacters('\u001B[1mHello\u001B[0m')) // [!code ++]
 Since Bun v1.2.21, you can use the built-in [`Bun.stripANSI`](https://bun.com/blog/release-notes/bun-v1.2.21#bun-stripansi-simd-accelerated-ansi-escape-removal) method.
 
 ```js
-import { stripANSI } from 'bun' // [!code ++]
 import stripAnsi from 'strip-ansi' // [!code --]
+import { stripANSI } from 'bun' // [!code ++]
 
 console.log(stripAnsi('\u001B[31mHello World\u001B[0m')) // [!code --]
 console.log(Bun.stripANSI('\u001B[31mHello World\u001B[0m')) // [!code ++]

--- a/docs/guide/replacement-guides/strip-ansi.md
+++ b/docs/guide/replacement-guides/strip-ansi.md
@@ -8,8 +8,8 @@ Added in v16.11.0, [util.stripVTControlCharacters](https://nodejs.org/api/util.h
 import { stripVTControlCharacters } from 'node:util' // [!code ++]
 import stripAnsi from 'strip-ansi' // [!code --]
 
-console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
-console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
+console.log(stripAnsi('\u001B[4me18e\u001B[0m')) // [!code --]
+console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
 ```
 
 ## Deno
@@ -20,8 +20,8 @@ Deno implements the Node `util` API, and also provides [`util.stripVTControlChar
 import { stripVTControlCharacters } from 'node:util' // [!code ++]
 import stripAnsi from 'strip-ansi' // [!code --]
 
-console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
-console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
+console.log(stripAnsi('\u001B[4me18e\u001B[0m')) // [!code --]
+console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
 ```
 
 ## Bun
@@ -34,12 +34,12 @@ Bun provides two options:
 ```js
 // Node-compatible API
 import { stripVTControlCharacters } from 'node:util' // [!code ++]
-import stripAnsi from 'strip-ansi' // [!code --]
-
-console.log(stripAnsi('\u001b[1mHello\u001b[0m')); // [!code --]
-console.log(stripVTControlCharacters('\u001b[1mHello\u001b[0m')); // [!code ++]
-
 // Bun’s native API (>=1.2.21)
 import { stripANSI } from 'bun' // [!code ++]
-console.log(Bun.stripANSI('\u001b[31mHello World\u001b[0m')); // [!code ++]
+
+import stripAnsi from 'strip-ansi' // [!code --]
+
+console.log(stripAnsi('\u001B[1mHello\u001B[0m')) // [!code --]
+console.log(stripVTControlCharacters('\u001B[1mHello\u001B[0m')) // [!code ++]
+console.log(Bun.stripANSI('\u001B[31mHello World\u001B[0m')) // [!code ++]
 ```

--- a/docs/guide/replacement-guides/strip-ansi.md
+++ b/docs/guide/replacement-guides/strip-ansi.md
@@ -17,9 +17,11 @@ console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
 Deno implements the Node `util` API, and also provides [`util.stripVTControlCharacters`](https://docs.deno.com/api/node/util/~/stripVTControlCharacters). The usage is identical:
 
 ```js
-import { stripVTControlCharacters } from 'node:util';
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
+import stripAnsi from 'strip-ansi' // [!code --]
 
-console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // returns 'e18e'
+console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
+console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
 ```
 
 ## Bun
@@ -31,10 +33,13 @@ Bun provides two options:
 
 ```js
 // Node-compatible API
-import { stripVTControlCharacters } from 'node:util';
-console.log(stripVTControlCharacters('\u001b[1mHello\u001b[0m')); // 'Hello'
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
+import stripAnsi from 'strip-ansi' // [!code --]
+
+console.log(stripAnsi('\u001b[1mHello\u001b[0m')); // [!code --]
+console.log(stripVTControlCharacters('\u001b[1mHello\u001b[0m')); // [!code ++]
 
 // Bun’s native API (>=1.2.21)
-const plain = Bun.stripANSI('\u001b[31mHello World\u001b[0m');
-console.log(plain); // 'Hello World'
+import { stripANSI } from 'bun' // [!code ++]
+console.log(Bun.stripANSI('\u001b[31mHello World\u001b[0m')); // [!code ++]
 ```

--- a/docs/guide/replacement-guides/strip-ansi.md
+++ b/docs/guide/replacement-guides/strip-ansi.md
@@ -29,7 +29,7 @@ console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
 Bun provides two options:
 
 1. [`util.stripVTControlCharacters`](https://bun.sh/reference/node/util/stripVTControlCharacters) is supported through Bun’s Node API layer.
-2. [Since Bun v1.2.21, `Bun.stripANSI`](https://bun.com/blog/release-notes/bun-v1.2.21#bun-stripansi-simd-accelerated-ansi-escape-removal) offers a high‑performance, SIMD‑accelerated alternative, often 6×–57× faster than strip-ansi.
+2. [Since Bun v1.2.21, `Bun.stripANSI`](https://bun.com/blog/release-notes/bun-v1.2.21#bun-stripansi-simd-accelerated-ansi-escape-removal) is available as a built‑in method for removing ANSI escape sequences.
 
 ```js
 // Node-compatible API

--- a/docs/guide/replacement-guides/strip-ansi.md
+++ b/docs/guide/replacement-guides/strip-ansi.md
@@ -1,4 +1,4 @@
-## Replacements for `strip-ansi`
+# Replacements for `strip-ansi`
 
 ## Node.js
 
@@ -14,24 +14,27 @@ console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
 
 ## Deno
 
-[Available via Node compat import](https://docs.deno.com/api/node/util/~/stripVTControlCharacters)
+Deno implements the Node `util` API, and also provides [`util.stripVTControlCharacters`](https://docs.deno.com/api/node/util/~/stripVTControlCharacters). The usage is identical:
 
 ```js
-import { stripVTControlCharacters } from 'node:util' // [!code ++]
-import stripAnsi from 'strip-ansi' // [!code --]
+import { stripVTControlCharacters } from 'node:util';
 
-console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
-console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
+console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // returns 'e18e'
 ```
 
 ## Bun
 
-[Bun supports the same API](https://bun.sh/reference/node/util/stripVTControlCharacters#node:util.stripVTControlCharacters)
+Bun provides two options:
+
+1. [`util.stripVTControlCharacters`](https://bun.sh/reference/node/util/stripVTControlCharacters) is supported through Bun’s Node API layer.
+2. [Since Bun v1.2.21, `Bun.stripANSI`](https://bun.com/blog/release-notes/bun-v1.2.21#bun-stripansi-simd-accelerated-ansi-escape-removal) offers a high‑performance, SIMD‑accelerated alternative, often 6×–57× faster than strip-ansi.
 
 ```js
-import { stripVTControlCharacters } from 'node:util' // [!code ++]
-import stripAnsi from 'strip-ansi' // [!code --]
+// Node-compatible API
+import { stripVTControlCharacters } from 'node:util';
+console.log(stripVTControlCharacters('\u001b[1mHello\u001b[0m')); // 'Hello'
 
-console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
-console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
+// Bun’s native API (>=1.2.21)
+const plain = Bun.stripANSI('\u001b[31mHello World\u001b[0m');
+console.log(plain); // 'Hello World'
 ```

--- a/docs/guide/replacement-guides/strip-ansi.md
+++ b/docs/guide/replacement-guides/strip-ansi.md
@@ -26,20 +26,26 @@ console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')) // [!code ++]
 
 ## Bun
 
-Bun provides two options:
+### Using Node‑compatible API
 
-1. [`util.stripVTControlCharacters`](https://bun.sh/reference/node/util/stripVTControlCharacters) is supported through Bun’s Node API layer.
-2. [Since Bun v1.2.21, `Bun.stripANSI`](https://bun.com/blog/release-notes/bun-v1.2.21#bun-stripansi-simd-accelerated-ansi-escape-removal) is available as a built‑in method for removing ANSI escape sequences.
+Bun also implements Node’s [`util.stripVTControlCharacters`](https://bun.sh/reference/node/util/stripVTControlCharacters) through its Node compat layer:
 
 ```js
-// Node-compatible API
 import { stripVTControlCharacters } from 'node:util' // [!code ++]
-// Bun’s native API (>=1.2.21)
-import { stripANSI } from 'bun' // [!code ++]
-
 import stripAnsi from 'strip-ansi' // [!code --]
 
 console.log(stripAnsi('\u001B[1mHello\u001B[0m')) // [!code --]
 console.log(stripVTControlCharacters('\u001B[1mHello\u001B[0m')) // [!code ++]
+```
+
+### Using Bun's native API (>=1.2.21)
+
+Since Bun v1.2.21, you can use the built-in [`Bun.stripANSI`](https://bun.com/blog/release-notes/bun-v1.2.21#bun-stripansi-simd-accelerated-ansi-escape-removal) method.
+
+```js
+import { stripANSI } from 'bun' // [!code ++]
+import stripAnsi from 'strip-ansi' // [!code --]
+
+console.log(stripAnsi('\u001B[31mHello World\u001B[0m')) // [!code --]
 console.log(Bun.stripANSI('\u001B[31mHello World\u001B[0m')) // [!code ++]
 ```

--- a/docs/guide/replacement-guides/strip-ansi.md
+++ b/docs/guide/replacement-guides/strip-ansi.md
@@ -1,0 +1,37 @@
+## Replacements for `strip-ansi`
+
+## Node.js
+
+Added in v16.11.0, [util.stripVTControlCharacters](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) can be used to strip ANSI escape codes from a string.
+
+```js
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
+import stripAnsi from 'strip-ansi' // [!code --]
+
+console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
+console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
+```
+
+## Deno
+
+[Available via Node compat import](https://docs.deno.com/api/node/util/~/stripVTControlCharacters)
+
+```js
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
+import stripAnsi from 'strip-ansi' // [!code --]
+
+console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
+console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
+```
+
+## Bun
+
+[Bun supports the same API](https://bun.sh/reference/node/util/stripVTControlCharacters#node:util.stripVTControlCharacters)
+
+```js
+import { stripVTControlCharacters } from 'node:util' // [!code ++]
+import stripAnsi from 'strip-ansi' // [!code --]
+
+console.log(stripAnsi('\u001B[4me18e\u001B[0m')); // [!code --]
+console.log(stripVTControlCharacters('\u001B[4me18e\u001B[0m')); // [!code ++]
+```

--- a/docs/guide/replacements.md
+++ b/docs/guide/replacements.md
@@ -34,5 +34,6 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`read-package-up`](./replacement-guides/read-package-up.md) | :x: |
 | [`read-pkg-up`](./replacement-guides/read-pkg-up.md) | :x: |
 | [`read-pkg`](./replacement-guides/read-pkg.md) | :x: |
+| [`rimraf`](./replacement-guides/rimraf.md) | :x: |
 | [`strip-ansi`](./replacement-guides/strip-ansi.md) | :x: |
 

--- a/docs/guide/replacements.md
+++ b/docs/guide/replacements.md
@@ -17,6 +17,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`chalk`](./replacement-guides/chalk.md) | :x: |
 | [`deep-equal`](./replacement-guides/deep-equal.md) | :x: |
 | [`emoji-regex`](./replacement-guides/emoji-regex.md) | :x: |
+| [`eslint-plugin-es`](./replacement-guides/eslint-plugin-es.md) | :x: |
 | [`eslint-plugin-node`](./replacement-guides/eslint-plugin-node.md) | :x: |
 | [`eslint-plugin-vitest`](./replacement-guides/eslint-plugin-vitest.md) | :x: |
 | [`find-cache-dir`](./replacement-guides/find-cache-dir.md) | :x: |
@@ -29,8 +30,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`md5`](./replacement-guides/md5.md) | :x: |
 | [`pkg-dir`](./replacement-guides/pkg-dir.md) | :x: |
 | [`read-package-up`](./replacement-guides/read-package-up.md) | :x: |
-| [`read-pkg`](./replacement-guides/read-pkg.md) | :x: |
 | [`read-pkg-up`](./replacement-guides/read-pkg-up.md) | :x: |
+| [`read-pkg`](./replacement-guides/read-pkg.md) | :x: |
 | [`strip-ansi`](./replacement-guides/strip-ansi.md) | :x: |
-| [`eslint-plugin-es`](./replacement-guides/eslint-plugin-es.md) | :x: |
 

--- a/docs/guide/replacements.md
+++ b/docs/guide/replacements.md
@@ -31,3 +31,6 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`read-package-up`](./replacement-guides/read-package-up.md) | :x: |
 | [`read-pkg`](./replacement-guides/read-pkg.md) | :x: |
 | [`read-pkg-up`](./replacement-guides/read-pkg-up.md) | :x: |
+| [`strip-ansi`](./replacement-guides/strip-ansi.md) | :x: |
+| [`eslint-plugin-es`](./replacement-guides/eslint-plugin-es.md) | :x: |
+

--- a/docs/guide/replacements.md
+++ b/docs/guide/replacements.md
@@ -18,6 +18,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`deep-equal`](./replacement-guides/deep-equal.md) | :x: |
 | [`emoji-regex`](./replacement-guides/emoji-regex.md) | :x: |
 | [`eslint-plugin-es`](./replacement-guides/eslint-plugin-es.md) | :x: |
+| [`eslint-plugin-eslint-comments.md`](./replacement-guides/eslint-plugin-eslint-comments.md) | :x: |
 | [`eslint-plugin-node`](./replacement-guides/eslint-plugin-node.md) | :x: |
 | [`eslint-plugin-vitest`](./replacement-guides/eslint-plugin-vitest.md) | :x: |
 | [`find-cache-dir`](./replacement-guides/find-cache-dir.md) | :x: |
@@ -28,6 +29,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`glob`](./replacement-guides/glob.md) | :x: |
 | [`is-builtin-module`](./replacement-guides/is-builtin-module.md) | :x: |
 | [`md5`](./replacement-guides/md5.md) | :x: |
+| [`npm-run-all`](./replacement-guides/npm-run-all.md) | :x: |
 | [`pkg-dir`](./replacement-guides/pkg-dir.md) | :x: |
 | [`read-package-up`](./replacement-guides/read-package-up.md) | :x: |
 | [`read-pkg-up`](./replacement-guides/read-pkg-up.md) | :x: |

--- a/docs/guide/replacements.md
+++ b/docs/guide/replacements.md
@@ -18,7 +18,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`deep-equal`](./replacement-guides/deep-equal.md) | :x: |
 | [`emoji-regex`](./replacement-guides/emoji-regex.md) | :x: |
 | [`eslint-plugin-es`](./replacement-guides/eslint-plugin-es.md) | :x: |
-| [`eslint-plugin-eslint-comments.md`](./replacement-guides/eslint-plugin-eslint-comments.md) | :x: |
+| [`eslint-plugin-eslint-comments`](./replacement-guides/eslint-plugin-eslint-comments.md) | :x: |
 | [`eslint-plugin-node`](./replacement-guides/eslint-plugin-node.md) | :x: |
 | [`eslint-plugin-vitest`](./replacement-guides/eslint-plugin-vitest.md) | :x: |
 | [`find-cache-dir`](./replacement-guides/find-cache-dir.md) | :x: |

--- a/docs/guide/replacements.md
+++ b/docs/guide/replacements.md
@@ -36,4 +36,3 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`read-pkg`](./replacement-guides/read-pkg.md) | :x: |
 | [`rimraf`](./replacement-guides/rimraf.md) | :x: |
 | [`strip-ansi`](./replacement-guides/strip-ansi.md) | :x: |
-


### PR DESCRIPTION
this PR adds:

- `eslint-plugin-es`
- `eslint-plugin-eslint-comments`
- `npm-run-all`
- `rimraf`
- `strip-ansi`

to the replacements guide