### PR TITLE
fix: mark guide nav link inactive on replacements page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
     },
 
     nav: [
-      { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
+      { text: 'Guide', link: '/guide/', activeMatch: '/guide/(?!replacements)' },
       { text: 'Blog', link: '/blog' },
       { text: 'Replacements', link: '/guide/replacements' },
     ],


### PR DESCRIPTION
Previously on the replacements page, both nav links were highlighted which I think is a bit confusing:
<img width="272" height="47" alt="image" src="https://github.com/user-attachments/assets/3fa0f362-4002-4d69-b744-ef47df1cd8fc" />
