### PR TITLE
docs: add `bluebird` & `q` replacements

### DIFF
--- a/docs/docs/replacements/bluebird-q.md
+++ b/docs/docs/replacements/bluebird-q.md
@@ -1,0 +1,13 @@
+---
+description: Modern alternatives to the Bluebird and Q Promise libraries for async control flow in JavaScript
+---
+
+# Replacements for `bluebird` / `q`
+
+## `Promise` (native)
+
+[`bluebird`](https://github.com/petkaantonov/bluebird?tab=readme-ov-file#%EF%B8%8Fnote%EF%B8%8F) and [`q`](https://github.com/kriskowal/q#note) recommend switching away from them to native promises.
+
+## NativeBird
+
+[`NativeBird`](https://github.com/doodlewind/nativebird) is an ultralight native `Promise` extension that provides Bluebird-like helpers if you miss a few conveniences from Bluebird.

--- a/docs/docs/replacements/index.md
+++ b/docs/docs/replacements/index.md
@@ -11,6 +11,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | -- | -- |
 | [`@jsdevtools/ez-spawn`](./ez-spawn.md) | :x: |
 | [`axios`](./axios.md) | :x: |
+| [`bluebird`](./bluebird-q.md) | :x: |
 | [`body-parser`](./body-parser.md) | :x: |
 | [`buf-compare`](./buf-compare.md) | :x: |
 | [`buffer-equal`](./buffer-equal.md) | :x: |


### PR DESCRIPTION
https://github.com/es-tooling/module-replacements/blob/main/docs/modules/bluebird-q.md

While researching the issue, I prepared two repositories demonstrating migration paths from Bluebird (see https://github.com/outslept/migrate-from-bluebird) and from Q (see https://github.com/outslept/migrate-from-q) respectively, as I initially expected the migration to be more complex. 

From what I can tell, the syntax-level migration should be straightforward for most users; the primary variable is whether consumer's environment supports the required features. Given the abundance of existing community posts on migrating away from these libraries, I decided to omit code blocks




