### PR TITLE
docs: add `eslint-plugin-react` replacements

### DIFF
--- a/docs/docs/replacements/eslint-plugin-react.md
+++ b/docs/docs/replacements/eslint-plugin-react.md
@@ -1,0 +1,36 @@
+---
+description: Modern alternatives to the eslint-plugin-react package for React/JSX-specific linting rules
+---
+
+# Replacements for `eslint-plugin-react`
+
+## `@eslint-react/eslint-plugin`
+
+[`@eslint-react/eslint-plugin`](https://github.com/Rel1cx/eslint-react) is not a drop-in replacement, but a feature‑rich alternative that covers many of the same (and additional) rules.
+
+Flat config example:
+
+```js
+import eslintReact from '@eslint-react/eslint-plugin' // [!code ++]
+import reactPlugin from 'eslint-plugin-react' // [!code --]
+
+export default [
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: {
+      'react': reactPlugin, // [!code --]
+      '@eslint-react': eslintReact, // [!code ++]
+    },
+    rules: {
+      ...reactPlugin.configs.recommended.rules, // [!code --]
+      ...eslintReact.configs.recommended.rules, // [!code ++]
+
+      'react/no-unknown-property': 'error', // [!code --]
+      '@eslint-react/dom/no-unknown-property': 'error', // [!code ++]
+    },
+  },
+]
+```
+
+> [!NOTE]
+> `@eslint-react/eslint-plugin` is not a drop‑in replacement. Use [their migration guide](https://eslint-react.xyz/docs/migration) to map rules/options and automate changes where possible.

--- a/docs/docs/replacements/index.md
+++ b/docs/docs/replacements/index.md
@@ -27,6 +27,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 | [`eslint-plugin-eslint-comments`](./eslint-plugin-eslint-comments.md) | :x: |
 | [`eslint-plugin-import`](./eslint-plugin-import.md) | :x: |
 | [`eslint-plugin-node`](./eslint-plugin-node.md) | :x: |
+| [`eslint-plugin-react`](./eslint-plugin-react.md) | :x: |
 | [`eslint-plugin-vitest`](./eslint-plugin-vitest.md) | :x: |
 | [`execa`](./execa.md) | :x: |
 | [`ez-spawn`](./ez-spawn.md) | :x: |


### PR DESCRIPTION
https://github.com/es-tooling/module-replacements/blob/main/docs/modules/eslint-plugin-react.md

Turns outs their migration guide is quite comprehensive already, I’ve submitted a small PR to their docs to fix a few minor inaccuracies (see https://github.com/Rel1cx/eslint-react/pull/1242)