### PR TITLE
Add note about Node version for OIDC support in publishing guide

### DIFF
--- a/docs/docs/publishing.md
+++ b/docs/docs/publishing.md
@@ -92,7 +92,7 @@ While you're in there, also check the box for "Require two-factor authentication
 > It can be a slow job opening all of your packages individually and changing these settings. To assist with this, you can use the [open-packages-on-npm](https://github.com/antfu/open-packages-on-npm) tool in your local repository to open the package(s) on npm, each in a new tab. You can then use this [userscript](https://github.com/sxzz/userscripts/blob/main/src/npm-trusted-publisher.md) to quickly update the trusted publisher settings on each page.
 
 > [!NOTE]
-> Make sure your GitHub workflow is using Node.js v24.8.0 or higher for the publish step. This ensures automatic trusted publishing is supported for npm.
+> Make sure your GitHub workflow is using Node.js v24.8.0 or higher for the publish step. This ensures automatic trusted publishing is supported for npm. Alternatively, you can force npm to update by running `npm i -g npm` in a step in the workflow before you publish.
 
 ## Standard Workflow
 


### PR DESCRIPTION
This PR adds a small note to the publishing guide indicating the minimum Node version required for automatic support for trusted publishing.

Closes #140 