### PR TITLE
docs: add gray-matter replacement

### DIFF
--- a/docs/docs/replacements/gray-matter.md
+++ b/docs/docs/replacements/gray-matter.md
@@ -1,0 +1,29 @@
+---
+description: Modern frontmatter parsers
+---
+
+# Replacements for `gray-matter` / `frontmatter`
+
+## `simplematter`
+
+[`simplematter`](https://github.com/remcohaszing/simplematter) is an up-to-date and minimal library that can parse YAML and TOML frontmatter data from strings.
+
+Example:
+
+```ts
+import matter from 'gray-matter' // [!code --]
+import { simplematter } from 'simplematter' // [!code ++]
+
+const document = `---
+title: e18e
+---
+
+# Hello e18e!
+`
+
+const { data, content } = matter(document) // [!code --]
+const [data, content] = simplematter(document) // [!code ++]
+
+console.log(data)
+console.log(content)
+```


### PR DESCRIPTION
I wrote a tiny frontmatter parser. I felt the need, because existing parsers have outdated dependencies.

Of course `simplematter` isn’t as battle-tested as `gray-matter`. I also kept it minimal on purpose. It doesn’t support specifying the language on a frontmatter fence, custom delimiters, or reading files.