### PR TITLE
Recommend isDeepStrictEqual

### DIFF
--- a/docs/docs/replacements/deep-equal.md
+++ b/docs/docs/replacements/deep-equal.md
@@ -4,6 +4,23 @@ description: Modern alternatives to the deep-equal package for deep object compa
 
 # Replacements for `deep-equal`
 
+## Node.js
+
+Node.js has a builtin function [`isDeepStrictEqual`](https://nodejs.org/api/util.html#utilisdeepstrictequalval1-val2-options). Consider using that if you don’t need browser support.
+
+Example:
+
+```ts
+import equal from 'deep-equal' // [!code --]
+import { isDeepStrictEqual } from 'node:util' // [!code ++]
+
+const a = { foo: 'bar' }
+const b = { foo: 'bar' }
+
+equal(a, b) // true [!code --]
+isDeepStrictEqual(a, b) // true [!code ++]
+```
+
 ## `dequal`
 
 [`dequal`](https://www.npmjs.com/package/dequal) has the same simple API as deep equal.


### PR DESCRIPTION
There are some recommended libraries to replace `deep-equal`. In Node.js however, this dependency can be replaced with the builtin `isDeepStrictEqual`.