### PR TITLE
feat: add `/r/:module` redirect

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -2,3 +2,4 @@
 /guide/replacements /docs/replacements 301
 /guide/replacement-guides/* /docs/replacements/:splat 301
 /guide/* /learn/:splat 301
+/r/:module /docs/replacements/:module 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,3 @@ NODE_OPTIONS = "--max_old_space_size=4096"
 
 [functions]
 node_bundler = "esbuild"
-
-[[redirects]]
-from = "/r/:module"
-to = "/docs/replacements/:module.html"


### PR DESCRIPTION
updates `netlify.toml` to redirect `e18e.dev/r/chalk` -> `e18e.dev/docs/replacements/chalk.html`

this would be very helpful to keep logs as minimal as possible in the cli (and likely other contexts)