### PR TITLE
docs: make sponsors on readme clickable and centered

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ See [Contributing Guide](https://github.com/e18e/e18e/blob/main/CONTRIBUTING.md)
 
 ## Sponsors
 
-![e18e community sponsors](./docs/public/sponsors.svg)
+<p align="center">
+  <a href="https://e18e.dev/sponsors.svg">
+    <img src="https://e18e.dev/sponsors.svg" alt="e18e community sponsors" />
+  </a>
+</p>
 
 ## License
 


### PR DESCRIPTION
Make the sponsors image a link so you can open it and then click on the people that sponsored, also centering it

before:

<img width="2104" height="1559" alt="image" src="https://github.com/user-attachments/assets/7718e344-c131-408c-bca1-737f0f1bd019" />

after:

<img width="2104" height="1559" alt="image" src="https://github.com/user-attachments/assets/e41d8195-12d4-49a9-89f5-e24b99aa3360" />
