### PR TITLE
docs: update section on github environments 

### DIFF
--- a/docs/docs/publishing.md
+++ b/docs/docs/publishing.md
@@ -232,9 +232,9 @@ You can use Github environments to enforce branch protection rules and prevent b
 Environments are managed under `https://github.com/<your-repo>/settings/environments`
 
 - Create one for publishing e.g. `publish`
-  - do not allow administrators bypass protection rules
-  - Limit it to only allow your active release branches (eg. `main`, `v1`, `v2`). Do not use patterns, hardcode exact branch names and remove them from the environment when they are no longer active.
-- add the `environment` key in your publish job
+  - Do not allow administrators bypass protection rules
+  - Limit it to only allow your active release branches (e.g. `main`, `v1`, `v2`). Do not use patterns, hardcode exact branch names and remove them from the environment when they are no longer active.
+- Add the `environment` key in your publish job
   ```yaml [publish.yml]
   jobs:
     publish:


### PR DESCRIPTION
to highlight the importance of environments for oidc

The important part is adding the branches to the environment and adding the environment to npm settings, only the combination of these two (and the branch protection rules) make it safe in repositories where many users have write access.

Manual approval on publish environments can be quite noisy, esp. with changesets where it requires extra work to separate - "create or update release PR" and "publish release" or in repositories with lots of packages and releases.