### PR TITLE
docs: add sponsors page

### DIFF
--- a/docs/sponsor.md
+++ b/docs/sponsor.md
@@ -1,0 +1,12 @@
+---
+title: Sponsors
+description: Information about our sponsorships and how to get involved.
+---
+
+# Sponsors
+
+e18e (Ecosystem Performance) is an initiative to connect the folks and projects working to improve the performance of JS packages. Sponsorships make a lot of our community's work possible. We primarily use them to reward members who have made great steps ahead in the ecosystem, or to fund larger projects which need more attention. You can support us financially, or by getting involved in the community.
+
+If you sponsor us on [Open Collective](https://opencollective.com/e18e), your avatar will be shown across all of our projects, as shown below.
+
+![e18e community sponsors](/sponsors.svg)


### PR DESCRIPTION
Add a sponsorship page so we can link to it from places off-site, like the sponsor image cards in the readme, so that we can update that page as needed without having to update individual places every time