### PR TITLE
fix: replacements action failed to clone replacements

### DIFF
--- a/.github/workflows/sync-replacements.yml
+++ b/.github/workflows/sync-replacements.yml
@@ -14,10 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'e18e/e18e'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout e18e repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: e18e
 
       - name: Get current pinned SHA
         id: current
+        working-directory: e18e
         run: echo "sha=$(cat scripts/module-replacements.sha)" >> "$GITHUB_OUTPUT"
 
       - name: Get latest upstream SHA
@@ -35,7 +39,7 @@ jobs:
         with:
           repository: es-tooling/module-replacements
           ref: ${{ steps.latest.outputs.sha }}
-          path: /tmp/module-replacements
+          path: module-replacements
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         if: steps.check.outputs.changed == 'true'
@@ -44,12 +48,14 @@ jobs:
 
       - name: Update SHA and generate docs
         if: steps.check.outputs.changed == 'true'
+        working-directory: e18e
         run: |
           echo "${{ steps.latest.outputs.sha }}" > scripts/module-replacements.sha
-          node scripts/generate-replacement-docs.js --path /tmp/module-replacements
+          node scripts/generate-replacement-docs.js --path "${{ github.workspace }}/module-replacements"
 
       - name: Create pull request
         if: steps.check.outputs.changed == 'true'
+        working-directory: e18e
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
I noticed that the [sync replacements action was failing](https://github.com/e18e/e18e/actions/runs/22300987895/job/64508526305), because the tmp directory is outside of the github workspace directory. There doesn't seem to be a way to use `actions/checkout` with a temp directory like that, so instead I cloned the two repos side-by-side.

It seems to work well, tested it on my fork:

<img width="909" height="372" alt="image" src="https://github.com/user-attachments/assets/f88b9d23-ddb7-4bb9-bb09-7d53e2490faf" />

<img width="1343" height="1053" alt="image" src="https://github.com/user-attachments/assets/fcb61009-396c-46fb-9fb3-496664571c5e" />

<details>
<summary>action logs</summary>

<img width="895" height="431" alt="image" src="https://github.com/user-attachments/assets/69c1c2b0-4a19-45d8-b58e-ccece75c73d6" />


</details>