### PR TITLE
chore: rename e18e repos

### DIFF
--- a/.github/workflows/sync-replacements.yml
+++ b/.github/workflows/sync-replacements.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get latest upstream SHA
         id: latest
-        run: echo "sha=$(git ls-remote https://github.com/es-tooling/module-replacements.git refs/heads/main | cut -f1)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git ls-remote https://github.com/e18e/module-replacements.git refs/heads/main | cut -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Check for changes
         if: steps.current.outputs.sha != steps.latest.outputs.sha
@@ -37,7 +37,7 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: es-tooling/module-replacements
+          repository: e18e/module-replacements
           ref: ${{ steps.latest.outputs.sha }}
           path: module-replacements
 
@@ -70,5 +70,5 @@ jobs:
               --title "chore: sync module replacements" \
               --body "Updates pinned module-replacements SHA from \`${{ steps.current.outputs.sha }}\` to \`${{ steps.latest.outputs.sha }}\`.
 
-          [View upstream changes](https://github.com/es-tooling/module-replacements/compare/${{ steps.current.outputs.sha }}...${{ steps.latest.outputs.sha }})"
+          [View upstream changes](https://github.com/e18e/module-replacements/compare/${{ steps.current.outputs.sha }}...${{ steps.latest.outputs.sha }})"
           fi

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     editLink: {
       pattern: ({ filePath }) => {
         if (filePath.startsWith('docs/replacements/')) {
-          return `https://github.com/es-tooling/module-replacements/edit/main/${filePath.replace('docs/replacements/', 'docs/modules/')}`
+          return `https://github.com/e18e/module-replacements/edit/main/${filePath.replace('docs/replacements/', 'docs/modules/')}`
         }
         return `https://github.com/e18e/e18e/edit/main/docs/${filePath}`
       },

--- a/docs/blog/e18e.md
+++ b/docs/blog/e18e.md
@@ -43,9 +43,9 @@ Often there are already actively maintained, battle tested alternatives but main
 
 There are several efforts to help these maintainers out by replacing or updating such dependencies:
 
-- The [ecosystem cleanup](https://github.com/43081j/ecosystem-cleanup) project.
-- The [module replacements](https://github.com/es-tooling/module-replacements) project.
-- The [eslint-plugin-depend](https://github.com/es-tooling/eslint-plugin-depend/) plugin.
+- The [ecosystem issues](https://github.com/e18e/ecosystem-issues) project.
+- The [module replacements](https://github.com/e18e/module-replacements) project.
+- The [eslint-plugin-depend](https://github.com/es-tooling/eslint-plugin-depend) plugin.
 
 ## Speed up
 

--- a/docs/blog/es-tooling.md
+++ b/docs/blog/es-tooling.md
@@ -35,8 +35,8 @@ Over the last few months, many of us have collaborated and connected through the
 
 A few popular projects that were running solo until now, have come together to create this:
 
-- [ecosystem-cleanup](https://github.com/43081j/ecosystem-cleanup).
-- [module-replacements](https://github.com/es-tooling/module-replacements).
+- [ecosystem-issue](https://github.com/e18e/ecosystem-issues).
+- [module-replacements](https://github.com/e18e/module-replacements).
 - [module-replacements-codemods](https://github.com/thepassle/module-replacements-codemods)
 - [fd-package-json](https://github.com/es-tooling/fd-package-json)
 
@@ -56,7 +56,7 @@ The cleanup project exists primarily as an issue tracker, tracking:
 
 If you want to help out, this project is a good starting point to find some open issues.
 
-Read more at the [ecosystem cleanup project](https://github.com/es-tooling/ecosystem-cleanup).
+Read more at the [ecosystem cleanup project](https://github.com/e18e/ecosystem-issues).
 
 ## Module replacements
 
@@ -64,7 +64,7 @@ The module replacements project is a community-led list of popular npm packages 
 
 Often, these replacements are native, or much faster and more modern packages. If you know of a good alternative to something, get involved and add to the list!
 
-Read more at the [module replacements project](https://github.com/es-tooling/module-replacements).
+Read more at the [module replacements project](https://github.com/e18e/module-replacements).
 
 ## Module replacements codemods
 

--- a/docs/blog/journey-so-far.md
+++ b/docs/blog/journey-so-far.md
@@ -50,7 +50,7 @@ Unfortunately, none of these efforts really went anywhere. I struggled to find a
 
 ## Starting a cleanup
 
-Eventually, I created the [ecosystem-cleanup](https://github.com/es-tooling/ecosystem-cleanup) project as place to track performance improvements in popular open source projects.
+Eventually, I created the [ecosystem-cleanup](https://github.com/e18e/ecosystem-issues) project as place to track performance improvements in popular open source projects.
 
 In the early days, this was basically me creating issues for myself to contribute to various OSS projects. Things like:
 
@@ -91,8 +91,8 @@ All of these people and many others were working on some aspect of performance. 
 
 Several months later, here's a few stats from the past year:
 
-- ~150 issues in the [cleanup project](https://github.com/es-tooling/ecosystem-cleanup/) to track contributions to performance of other projects
-- ~100 merged PRs in the [module-replacements project](https://github.com/es-tooling/module-replacements) to document performant replacements to popular modules
+- ~150 issues in the [cleanup project](https://github.com/e18e/ecosystem-issues/) to track contributions to performance of other projects
+- ~100 merged PRs in the [module-replacements project](https://github.com/e18e/module-replacements) to document performant replacements to popular modules
 - ~150 codemods in the [module-replacements-codemods project](https://github.com/es-tooling/module-replacements-codemods) to automatically migrate to suggested replacements
 - 1000+ members in the [discord](https://chat.e18e.dev)
 

--- a/docs/blog/july-contributions-showcase.md
+++ b/docs/blog/july-contributions-showcase.md
@@ -47,7 +47,7 @@ You can read about how this was achieve through these two PRs in particular:
 
 ## codemods
 
-One of the biggest steps forward with the [replacements project](https://github.com/es-tooling/module-replacements) has certainly been the [codemods](https://github.com/es-tooling/module-replacements-codemods) repo.
+One of the biggest steps forward with the [replacements project](https://github.com/e18e/module-replacements) has certainly been the [codemods](https://github.com/es-tooling/module-replacements-codemods) repo.
 
 If you haven't yet seen the replacements project, it basically provides community driven lists of suggested replacements to npm packages. These are then consumed by various tools, such as the [eslint plugin](https://github.com/es-tooling/eslint-plugin-depend).
 
@@ -61,7 +61,7 @@ The future of the [es-tooling](https://github.com/es-tooling) organisation will 
 
 While this hasn't been published yet, it is great progress, showing that even some aged projects are open to performance contributions.
 
-[This change](https://github.com/micromatch/to-regex-range/pull/17) removed, in this case, an unnecessary dependency often seen in the ongoing [cleanup work](https://github.com/es-tooling/ecosystem-cleanup/issues).
+[This change](https://github.com/micromatch/to-regex-range/pull/17) removed, in this case, an unnecessary dependency often seen in the ongoing [cleanup work](https://github.com/e18e/ecosystem-issues/issues).
 
 `is-number` may be small but is often entirely unnecessary. Most consumers can instead use something as simple as `typeof n === 'number'` and provide a stricter API rather than trying to coerce inputs.
 
@@ -73,13 +73,13 @@ Node has had a `recursive` option for `rmdir` (or `rm` in newer versions) for a 
 
 A small but effective win here is the [removal of rimraf](https://github.com/mapbox/node-pre-gyp/pull/720) from `node-pre-gyp`.
 
-It is worth mentioning, for those cases where you'd still like a CLI, you can use [an alternative](https://github.com/es-tooling/module-replacements/blob/main/docs/modules/rimraf.md).
+It is worth mentioning, for those cases where you'd still like a CLI, you can use [an alternative](https://github.com/e18e/module-replacements/blob/main/docs/modules/rimraf.md).
 
 Credit to [@benjaminmccann](https://x.com/benjaminmccann) for this one!
 
 ## picoquery
 
-As part of the [cleanup project](https://github.com/es-tooling/ecosystem-cleanup), we were in need of a fast and lightweight query-string parser/stringifier.
+As part of the [cleanup project](https://github.com/e18e/ecosystem-issues), we were in need of a fast and lightweight query-string parser/stringifier.
 
 Some excellent solutions exist for part of this:
 

--- a/docs/blog/november-contributions-showcase.md
+++ b/docs/blog/november-contributions-showcase.md
@@ -72,11 +72,11 @@ Sonda is a bundle analyzer which works with all popular bundlers and accurately 
 
 Another great contribution to the community recently is a tool by [@fuzzyma](https://bsky.app/profile/fuzzyma.bsky.social) which can determine the dependents of a given package.
 
-Feel free to explore [e18e-tools source](https://github.com/fuzzyma/e18e-tools) and [an example of the produced output](https://github.com/es-tooling/ecosystem-cleanup/issues/137#issue-2702026306).
+Feel free to explore [e18e-tools source](https://github.com/fuzzyma/e18e-tools) and [an example of the produced output](https://github.com/e18e/ecosystem-issues/issues/137#issue-2702026306).
 
 This is such a useful tool since we have no easy API access to find this information right now.
 
-In many of the issues of the [cleanup project](https://github.com/es-tooling/ecosystem-cleanup/), we now have an incredibly useful list of all the top dependents of the target package. This is making the cleanup work so much easier.
+In many of the issues of the [cleanup project](https://github.com/e18e/ecosystem-issues), we now have an incredibly useful list of all the top dependents of the target package. This is making the cleanup work so much easier.
 
 Big thanks to [@fuzzyma](https://bsky.app/profile/fuzzyma.bsky.social) and [@devminer.xyz](https://bsky.app/profile/devminer.xyz) for making this a thing!
 

--- a/docs/blog/npmx-collaboration.md
+++ b/docs/blog/npmx-collaboration.md
@@ -65,7 +65,7 @@ This is just the beginning of our collaboration and what we can achieve together
 - Adding richer advice with example code snippets and links to our tools
 - Highlighting packages with duplicate dependencies
 
-Thanks to our community-maintained [replacements data](https://github.com/es-tooling/module-replacements), much of this advice and more is already available to be surfaced.
+Thanks to our community-maintained [replacements data](https://github.com/e18e/module-replacements), much of this advice and more is already available to be surfaced.
 
 In addition to the module replacements data, we are also hard at work on a new data project which will provide enriched registry data. This will allow npmx and other tools to show things like license information, install sizes, and more.
 

--- a/docs/blog/october-contributions-showcase.md
+++ b/docs/blog/october-contributions-showcase.md
@@ -107,8 +107,8 @@ Just a couple of plugins that are moving ahead on this:
 
 Do note, the community lead alternatives will certainly live on as they drop even more opinionated dependencies and logic. If you want to reduce your install footprint and get some performance gains, check out the alternatives docs for them here:
 
-- [`eslint-plugin-import`](https://github.com/es-tooling/module-replacements/blob/main/docs/modules/eslint-plugin-import.md)
-- [`eslint-plugin-react`](https://github.com/es-tooling/module-replacements/blob/main/docs/modules/eslint-plugin-react.md)
+- [`eslint-plugin-import`](https://github.com/e18e/module-replacements/blob/main/docs/modules/eslint-plugin-import.md)
+- [`eslint-plugin-react`](https://github.com/e18e/module-replacements/blob/main/docs/modules/eslint-plugin-react.md)
 
 ### strip-ansi
 
@@ -155,7 +155,7 @@ As part of this becoming available, the e18e community is preparing to help in a
 
 Huge reductions will happen once we are able to stop publishing dual packages. Big wins ahead!
 
-If you want to help out with this, we're [tracking the work on GitHub](https://github.com/es-tooling/ecosystem-cleanup/issues/129).
+If you want to help out with this, we're [tracking the work on GitHub](https://github.com/e18e/ecosystem-issues/issues/129).
 
 ### porffor passes 50% of ECMAScript tests
 

--- a/docs/blog/september-contributions-showcase.md
+++ b/docs/blog/september-contributions-showcase.md
@@ -100,7 +100,7 @@ This has all been great to see and will hopefully lead to other large projects m
 
 The folks over at [nx](https://github.com/nrwl/nx/) have been incredibly active with the e18e community. They are definitely on the same page and have been moving fast to work with the community to land many improvements.
 
-You can see a lot of this in the [tracking issue](https://github.com/es-tooling/ecosystem-cleanup/issues/117) over on the ecosystem cleanup project. These issues are closing quickly, with contributions coming from a few different people in the e18e space.
+You can see a lot of this in the [tracking issue](https://github.com/e18e/ecosystem-issues/issues/117) over on the ecosystem cleanup project. These issues are closing quickly, with contributions coming from a few different people in the e18e space.
 
 Just a few examples of the improvements made:
 

--- a/docs/blog/the-year-ahead-2026.md
+++ b/docs/blog/the-year-ahead-2026.md
@@ -69,7 +69,7 @@ The e18e community and the Chrome team share a lot of the same goals - improving
 
 They have been very active as part of the [WebDX community group](https://www.w3.org/community/webdx/), a w3c group which aims to improve developer experience on the web. Two notable projects from this group will be fundamental for much of the tooling we're building in e18e - [baseline](https://web.dev/baseline), and the [web-features](https://github.com/web-platform-dx/web-features) project.
 
-As part of the next major version of the [module-replacements](https://github.com/es-tooling/module-replacements) data set, we will be integrating both baseline and web-features. These will allow us to make much smarter suggestions based on the target environments of a project, as well as being able to suggest syntax and API replacements based on feature support.
+As part of the next major version of the [module-replacements](https://github.com/e18e/module-replacements) data set, we will be integrating both baseline and web-features. These will allow us to make much smarter suggestions based on the target environments of a project, as well as being able to suggest syntax and API replacements based on feature support.
 
 This support is very much appreciated and will go a long way to helping us improve performance across the entire ecosystem :pray:
 
@@ -102,7 +102,7 @@ Follow along on [Discord](https://chat.e18e.dev) for updates :rocket:
 
 ## Module Replacements v3
 
-The [module replacements](https://github.com/es-tooling/module-replacements) project has been core to the e18e community since the beginning. It provides a data set which maps older, heavier dependencies to modern, more performant alternatives.
+The [module replacements](https://github.com/e18e/module-replacements) project has been core to the e18e community since the beginning. It provides a data set which maps older, heavier dependencies to modern, more performant alternatives.
 
 This has done a great job so far, but has been lacking a few notable things:
 

--- a/docs/docs/replacements/index.md
+++ b/docs/docs/replacements/index.md
@@ -4,7 +4,7 @@ When using the [ESLint plugin](https://github.com/es-tooling/eslint-plugin-depen
 
 ## What are these?
 
-The e18e community maintains a list of modules and their recommended replacements via the [module-replacements](https://github.com/es-tooling/module-replacements) repository.
+The e18e community maintains a list of modules and their recommended replacements via the [module-replacements](https://github.com/e18e/module-replacements) repository.
 
 Typically, a module might be flagged as replaceable if it:
 

--- a/docs/learn/cleanup.md
+++ b/docs/learn/cleanup.md
@@ -107,7 +107,7 @@ Common considerations include:
 
 If a dependency is replaceable, look for alternatives. Good resources include:
 
-- The [module replacements repository](https://github.com/es-tooling/module-replacements/tree/main/docs/modules)
+- The [module replacements repository](https://github.com/e18e/module-replacements/tree/main/docs/modules)
 - [tinylibs](https://github.com/tinylibs/)
 - [unjs](https://github.com/unjs/)
 

--- a/docs/learn/projects.md
+++ b/docs/learn/projects.md
@@ -20,7 +20,7 @@ A command-line tool for scanning your codebase to detect replaceable code and de
 
 An MCP (Model Context Protocol) server that advises AI agents on legacy code patterns and dependencies that should be replaced with modern alternatives.
 
-### [Module Replacements](https://github.com/es-tooling/module-replacements)
+### [Module Replacements](https://github.com/e18e/module-replacements)
 
 A community-maintained list of recommended replacements for outdated or suboptimal dependencies. Helps developers make informed decisions about modernizing their dependency stack.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 SHA=$(cat scripts/module-replacements.sha)
 CLONE_DIR="/tmp/module-replacements"
 
-echo "Cloning es-tooling/module-replacements at $SHA..."
-git clone --depth 1 https://github.com/es-tooling/module-replacements.git "$CLONE_DIR"
+echo "Cloning e18e/module-replacements at $SHA..."
+git clone --depth 1 https://github.com/e18e/module-replacements.git "$CLONE_DIR"
 git -C "$CLONE_DIR" fetch --depth 1 origin "$SHA"
 git -C "$CLONE_DIR" checkout "$SHA"
 


### PR DESCRIPTION
This updates links to point to e18e now that it holds the module-replacements repo and the ecosystem-issues repo.
