### PR TITLE
chore: fix sync-replacements workflow causing lint issues

### DIFF
--- a/.github/workflows/sync-replacements.yml
+++ b/.github/workflows/sync-replacements.yml
@@ -46,12 +46,23 @@ jobs:
         with:
           node-version: 22
 
+      - name: Use pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+      - name: Install Dependencies
+        if: steps.check.outputs.changed == 'true'
+        run: pnpm install --frozen-lockfile
+
       - name: Update SHA and generate docs
         if: steps.check.outputs.changed == 'true'
         working-directory: e18e
         run: |
           echo "${{ steps.latest.outputs.sha }}" > scripts/module-replacements.sha
           node scripts/generate-replacement-docs.js --path "${{ github.workspace }}/module-replacements"
+
+      - name: Lint
+        if: steps.check.outputs.changed == 'true'
+        run: pnpm lint:fix
 
       - name: Create pull request
         if: steps.check.outputs.changed == 'true'

--- a/docs/docs/replacements/index.md
+++ b/docs/docs/replacements/index.md
@@ -92,7 +92,7 @@ Where it was not possible to contribute upstream to the existing modules, replac
 | [`npm-run-all`](./npm-run-all.md)                                     | :x:                     |
 | [`object-hash`](./object-hash.md)                                     | :x:                     |
 | [`ora`](./ora.md)                                                     | :x:                     |
-| [`parseargs`](./parseargs.md) | :x: |
+| [`parseargs`](./parseargs.md)                                         | :x:                     |
 | [`path-exists`](./path-exists.md)                                     | :x:                     |
 | [`pbkdf2`](./pbkdf2.md)                                               | :x:                     |
 | [`pkg-dir`](./pkg-dir.md)                                             | :x:                     |


### PR DESCRIPTION
I noticed that CI failed after #203 was merged as it's not running lint:fix, so I updated the workflow to do that as well as fixing the formatting here

It does cause unnecessary installs but it's probably fine given it only runs once per week, and it feels less brittle than trying to install the exact packages - however can change it if you like :pray: 